### PR TITLE
Real contexts 🕊️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Added `ManagementMixin` to support `MessageContext`.
 - Added `banAuthor`, `banSenderChat`, `deleteChatPhoto`, `promoteAuthor`, `restrictAuthor`, `exportChatInviteLink`, `revokeChatInviteLink`, `pinChatMessage`, `unpinChatMessage`, `getChat`, `getChatAdministrators`, `getChatMember`, and `leaveChat` on `ManagementMixin`.
 - Both `MessageMixin` and `ManagementMixin` are now available on `MessageContext`.
+- Added `CallbackQueryMixin` to support `CallbackQueryContext`.
+- `CallbackQueryContext` now has `answer` and `editMessage` methods available.
+- Added `InlineQueryMixin` to support `InlineQueryContext`.
+- `InlineQueryContext` now has `answer`, and `answerWithArticles` methods available.
 ## 1.2.1
 - Fixed an issue with the `on` method that it's not getting called on any filters.
 - Made official [Televerse Wiki available at the GitHub repo.](https://github.com/HeySreelal/televerse/wiki)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Added `MessageMixin` to support `MessageContext`.
+- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice` methods to `MessageContext`.
 ## 1.2.1
 - Fixed an issue with the `on` method that it's not getting called on any filters.
 - Made official [Televerse Wiki available at the GitHub repo.](https://github.com/HeySreelal/televerse/wiki)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.2
 - Added `MessageMixin` to support `MessageContext`.
-- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice` methods to `MessageContext`.
+- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice`, `replyWithVenue`, `replyWithContact`, `replyWithPoll`, `replyWithDice`, `replyWithChatAction`, `replyWithGame`, `replyWithAnimation`, and `replyWithSticker` methods to `MessageContext`.
 ## 1.2.1
 - Fixed an issue with the `on` method that it's not getting called on any filters.
 - Made official [Televerse Wiki available at the GitHub repo.](https://github.com/HeySreelal/televerse/wiki)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.2
 - Added `MessageMixin` to support `MessageContext`.
-- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice`, `replyWithVenue`, `replyWithContact`, `replyWithPoll`, `replyWithDice`, `replyWithChatAction`, `replyWithGame`, `replyWithAnimation`, and `replyWithSticker` methods to `MessageContext`.
+- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice`, `replyWithVenue`, `replyWithContact`, `replyWithPoll`, `replyWithDice`, `replyWithChatAction`, `replyWithGame`, `replyWithAnimation`, `replyWithSticker`, `editMessageText`, and `deleteMessage` methods to `MessageContext`.
 ## 1.2.1
 - Fixed an issue with the `on` method that it's not getting called on any filters.
 - Made official [Televerse Wiki available at the GitHub repo.](https://github.com/HeySreelal/televerse/wiki)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.2.2
 - Added `MessageMixin` to support `MessageContext`.
 - Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice`, `replyWithVenue`, `replyWithContact`, `replyWithPoll`, `replyWithDice`, `replyWithChatAction`, `replyWithGame`, `replyWithAnimation`, `replyWithSticker`, `editMessageText`, and `deleteMessage` methods to `MessageContext`.
+- Added `ManagementMixin` to support `MessageContext`.
+- Added `banAuthor`, `banSenderChat`, `deleteChatPhoto`, `promoteAuthor`, `restrictAuthor`, `exportChatInviteLink`, `revokeChatInviteLink`, `pinChatMessage`, `unpinChatMessage`, `getChat`, `getChatAdministrators`, `getChatMember`, and `leaveChat` on `ManagementMixin`.
+- Both `MessageMixin` and `ManagementMixin` are now available on `MessageContext`.
 ## 1.2.1
 - Fixed an issue with the `on` method that it's not getting called on any filters.
 - Made official [Televerse Wiki available at the GitHub repo.](https://github.com/HeySreelal/televerse/wiki)

--- a/lib/src/televerse/context/callback_query.dart
+++ b/lib/src/televerse/context/callback_query.dart
@@ -7,7 +7,7 @@ class CallbackQueryContext extends Context {
   CallbackQueryContext(
     Televerse t,
     this.query, {
-    Update? update,
+    required Update update,
   }) : super(
           t,
           update: update,

--- a/lib/src/televerse/context/callback_query.dart
+++ b/lib/src/televerse/context/callback_query.dart
@@ -1,6 +1,6 @@
 part of televerse.context;
 
-class CallbackQueryContext extends Context {
+class CallbackQueryContext extends Context with CallbackQueryMixin {
   /// The incoming callback query.
   CallbackQuery query;
 
@@ -24,22 +24,6 @@ class CallbackQueryContext extends Context {
 
   /// The user of the query.
   User? get from => message?.from;
-
-  /// Answer the callback query.
-  Future<void> answer(
-    String? text, {
-    bool showAlert = false,
-    String? url,
-    int cacheTime = 0,
-  }) async {
-    await _televerse.answerCallbackQuery(
-      query.id,
-      text: text,
-      showAlert: showAlert,
-      url: url,
-      cacheTime: cacheTime,
-    );
-  }
 
   List<RegExpMatch>? matches;
 }

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -10,10 +10,54 @@ class Context {
   /// The televerse instance.
   Televerse get api => _televerse;
   final Televerse _televerse;
-  final Update? update;
+
+  /// The [Update] instance.
+  ///
+  /// This represents the update for which the context is created.
+  final Update update;
+
+  /// The [ChatID] instance.
+  ///
+  /// This represents the ID of the chat from which the update was sent.
+  ///
+  /// Note: On `poll`, and `unknown` updates, this will be `ChatID(0)`.
+  /// This is because these updates do not have a chat.
+  ID get id {
+    if (update.type == UpdateType.chatJoinRequest) {
+      return ChatID(update.chatJoinRequest!.chat.id);
+    }
+    if (update.type == UpdateType.chatMember) {
+      return ChatID(update.chatMember!.chat.id);
+    }
+    if (update.type == UpdateType.myChatMember) {
+      return ChatID(update.myChatMember!.chat.id);
+    }
+    if (update.type == UpdateType.preCheckoutQuery) {
+      return ChatID(update.preCheckoutQuery!.from.id);
+    }
+    if (update.type == UpdateType.shippingQuery) {
+      return ChatID(update.shippingQuery!.from.id);
+    }
+    if (update.type == UpdateType.callbackQuery) {
+      return ChatID(update.callbackQuery!.message!.chat.id);
+    }
+    if (update.type == UpdateType.inlineQuery) {
+      return ChatID(update.inlineQuery!.from.id);
+    }
+    if (update.type == UpdateType.chosenInlineResult) {
+      return ChatID(update.chosenInlineResult!.from.id);
+    }
+    if (update.type == UpdateType.pollAnswer) {
+      return ChatID(update.pollAnswer!.user.id);
+    }
+    if (update.type == UpdateType.poll || update.type == UpdateType.unknown) {
+      return ChatID(0);
+    }
+    return ChatID(update.message!.chat.id);
+  }
 
   Context(
     this._televerse, {
-    this.update,
+    required this.update,
   });
 }

--- a/lib/src/televerse/context/inline_query.dart
+++ b/lib/src/televerse/context/inline_query.dart
@@ -1,6 +1,6 @@
 part of televerse.context;
 
-class InlineQueryContext extends Context {
+class InlineQueryContext extends Context with InlineQueryMixin {
   /// The incoming inline query.
   InlineQuery query;
 

--- a/lib/src/televerse/context/inline_query.dart
+++ b/lib/src/televerse/context/inline_query.dart
@@ -7,7 +7,7 @@ class InlineQueryContext extends Context {
   InlineQueryContext(
     Televerse t,
     this.query, {
-    Update? update,
+    required Update update,
   }) : super(t, update: update);
 
   User get from => query.from;

--- a/lib/src/televerse/context/message.dart
+++ b/lib/src/televerse/context/message.dart
@@ -1,45 +1,17 @@
 part of televerse.context;
 
-class MessageContext extends Context {
+class MessageContext extends Context with MessageMixin {
   /// The incoming message.
   Message message;
 
   MessageContext(
     Televerse t,
     this.message, {
-    Update? update,
+    required Update update,
   }) : super(t, update: update);
 
   /// Chat of the message.
   Chat get chat => message.chat;
-
-  /// Reply a Text Message to the user.
-  Future<Message> reply(
-    String text, {
-    int? messageThreadId,
-    ParseMode? parseMode,
-    List<MessageEntity>? entities,
-    bool? disableWebPagePreview,
-    bool? disableNotification,
-    bool? protectContent,
-    int? replyToMessageId,
-    bool? allowSendingWithoutReply,
-    ReplyMarkup? replyMarkup,
-  }) async {
-    return await _televerse.sendMessage(
-      ChatID(chat.id),
-      text,
-      messageThreadId: messageThreadId,
-      parseMode: parseMode,
-      entities: entities,
-      disableWebPagePreview: disableWebPagePreview,
-      disableNotification: disableNotification,
-      protectContent: protectContent,
-      replyToMessageId: replyToMessageId,
-      allowSendingWithoutReply: allowSendingWithoutReply,
-      replyMarkup: replyMarkup,
-    );
-  }
 
   /// **Regular expression matches**
   ///
@@ -65,5 +37,6 @@ class MessageContext extends Context {
   /// ```
   ///
   /// Easy right? :)
+  @override
   ID get id => ChatID(message.chat.id);
 }

--- a/lib/src/televerse/context/message.dart
+++ b/lib/src/televerse/context/message.dart
@@ -1,6 +1,6 @@
 part of televerse.context;
 
-class MessageContext extends Context with MessageMixin {
+class MessageContext extends Context with MessageMixin, ManagementMixin {
   /// The incoming message.
   Message message;
 

--- a/lib/src/televerse/context/mixins/callback_mixin.dart
+++ b/lib/src/televerse/context/mixins/callback_mixin.dart
@@ -1,0 +1,70 @@
+part of televerse;
+
+/// Mixin for managing callback queries.
+///
+/// This includes methods like `answer`, `answerWithAlert`, `answerWithUrl`, `answerWithUrlAndAlert`.
+mixin CallbackQueryMixin on Context {
+  /// Answer the callback query.
+  Future<void> answer({
+    String? text,
+    bool showAlert = false,
+    String? url,
+    int cacheTime = 0,
+  }) async {
+    await api.answerCallbackQuery(
+      callbackQuery.id,
+      text: text,
+      showAlert: showAlert,
+      url: url,
+      cacheTime: cacheTime,
+    );
+  }
+
+  /// Answer the callback query with an alert.
+  Future<void> answerWithAlert({
+    String? text,
+    String? url,
+    int cacheTime = 0,
+  }) async {
+    await api.answerCallbackQuery(
+      callbackQuery.id,
+      text: text,
+      showAlert: true,
+      url: url,
+      cacheTime: cacheTime,
+    );
+  }
+
+  /// Answer the callback query with a URL.
+  Future<void> answerWithUrl({
+    String? text,
+    String url = '',
+    int cacheTime = 0,
+  }) async {
+    await api.answerCallbackQuery(
+      callbackQuery.id,
+      text: text,
+      showAlert: false,
+      url: url,
+      cacheTime: cacheTime,
+    );
+  }
+
+  /// Answer the callback query with a URL and an alert.
+  Future<void> answerWithUrlAndAlert({
+    String? text,
+    String url = '',
+    int cacheTime = 0,
+  }) async {
+    await api.answerCallbackQuery(
+      callbackQuery.id,
+      text: text,
+      showAlert: true,
+      url: url,
+      cacheTime: cacheTime,
+    );
+  }
+
+  /// The callback query.
+  CallbackQuery get callbackQuery => update.callbackQuery!;
+}

--- a/lib/src/televerse/context/mixins/callback_mixin.dart
+++ b/lib/src/televerse/context/mixins/callback_mixin.dart
@@ -65,6 +65,25 @@ mixin CallbackQueryMixin on Context {
     );
   }
 
+  /// Edit the message of the callback query.
+  Future<Message> editMessage(
+    String text, {
+    ParseMode? parseMode,
+    List<MessageEntity>? entities,
+    bool disableWebPagePreview = false,
+    InlineKeyboardMarkup? replyMarkup,
+  }) async {
+    return await api.editMessageText(
+      ChatID(callbackQuery.message!.chat.id),
+      callbackQuery.message!.messageId,
+      text,
+      parseMode: parseMode,
+      entities: entities,
+      disableWebPagePreview: disableWebPagePreview,
+      replyMarkup: replyMarkup,
+    );
+  }
+
   /// The callback query.
   CallbackQuery get callbackQuery => update.callbackQuery!;
 }

--- a/lib/src/televerse/context/mixins/inline_mixin.dart
+++ b/lib/src/televerse/context/mixins/inline_mixin.dart
@@ -1,0 +1,48 @@
+part of televerse;
+
+/// Mixin for managing inline queries.
+///
+/// This includes methods like `answer`, `answerWithArticles`.
+mixin InlineQueryMixin on Context {
+  InlineQuery get inlineQuery => update.inlineQuery!;
+
+  /// Answer the inline query.
+  Future<void> answer(
+    List<InlineQueryResult> results, {
+    int? cacheTime,
+    bool? isPersonal,
+    String? nextOffset,
+    String? switchPmText,
+    String? switchPmParameter,
+  }) async {
+    await api.answerInlineQuery(
+      inlineQuery.id,
+      results,
+      cacheTime: cacheTime,
+      isPersonal: isPersonal,
+      nextOffset: nextOffset,
+      switchPmText: switchPmText,
+      switchPmParameter: switchPmParameter,
+    );
+  }
+
+  /// Answer the inline query with a list of articles.
+  Future<void> answerWithArticles(
+    List<InlineQueryResultArticle> articles, {
+    int? cacheTime,
+    bool? isPersonal,
+    String? nextOffset,
+    String? switchPmText,
+    String? switchPmParameter,
+  }) async {
+    await api.answerInlineQuery(
+      inlineQuery.id,
+      articles,
+      cacheTime: cacheTime,
+      isPersonal: isPersonal,
+      nextOffset: nextOffset,
+      switchPmText: switchPmText,
+      switchPmParameter: switchPmParameter,
+    );
+  }
+}

--- a/lib/src/televerse/context/mixins/management.dart
+++ b/lib/src/televerse/context/mixins/management.dart
@@ -1,5 +1,10 @@
 part of televerse;
 
+/// Mixin that contains methods for managing the chat.
+///
+/// This includes methods like [banAuthor], [banSenderChat], [deleteChatPhoto],
+/// [promoteAuthor], [restrictAuthor], [setChatDescription], [setChatPermissions],
+/// [setChatPhoto], [setChatTitle], [unbanAuthor], [unbanSenderChat].
 mixin ManagementMixin on Context {
   /// **Ban the user**
   ///
@@ -149,5 +154,57 @@ mixin ManagementMixin on Context {
   /// This method will leave the chat in the current context.
   Future<bool> leaveChat() async {
     return await api.leaveChat(id);
+  }
+
+  /// Set Chat Description
+  ///
+  /// This method will set the chat description in the current context.
+  Future<bool> setChatDescription(String description) async {
+    return await api.setChatDescription(id, description);
+  }
+
+  /// Set Chat Permissions
+  ///
+  /// This method will set the chat permissions in the current context.
+  Future<bool> setChatPermissions(ChatPermissions permissions) async {
+    return await api.setChatPermissions(id, permissions);
+  }
+
+  /// Set Chat Photo
+  ///
+  /// This method will set the chat photo in the current context.
+  Future<bool> setChatPhoto(InputFile photo) async {
+    return await api.setChatPhoto(id, photo);
+  }
+
+  /// Set Chat Title
+  ///
+  /// This method will set the chat title in the current context.
+  Future<bool> setChatTitle(String title) async {
+    return await api.setChatTitle(id, title);
+  }
+
+  /// Unban Chat Member
+  ///
+  /// This method will unban the chat member in the current context.
+  Future<bool> unbanAuthor(
+    int userId, {
+    bool? onlyIfBanned,
+  }) async {
+    return await api.unbanChatMember(
+      id,
+      userId,
+      onlyIfBanned: onlyIfBanned,
+    );
+  }
+
+  /// Unban Sender Chat
+  ///
+  /// This method will unban the sender chat in the current context.
+  Future<bool> unbanSenderChat(int senderChatId) async {
+    return await api.unbanChatSenderChat(
+      id,
+      senderChatId,
+    );
   }
 }

--- a/lib/src/televerse/context/mixins/management.dart
+++ b/lib/src/televerse/context/mixins/management.dart
@@ -1,0 +1,153 @@
+part of televerse;
+
+mixin ManagementMixin on Context {
+  /// **Ban the user**
+  ///
+  /// This method will ban the user who sent the message in the current context.
+  Future<bool> banAuthor({
+    DateTime? untilDate,
+    bool? revokeMessages,
+  }) async {
+    return await api.banChatMember(
+      id,
+      update.message!.from!.id,
+      untilDate: untilDate,
+      revokeMessages: revokeMessages,
+    );
+  }
+
+  /// Ban Sender Chat
+  ///
+  /// This method will ban the chat that sent the message in the current context.
+  Future<bool> banSenderChat({
+    DateTime? untilDate,
+    bool? revokeMessages,
+  }) async {
+    return await api.banChatSenderChat(
+      id,
+      update.message!.senderChat!.id,
+    );
+  }
+
+  /// Delete Chat Photo
+  ///
+  /// This method will delete the chat photo in the current context.
+  Future<bool> deleteChatPhoto() async {
+    return await api.deleteChatPhoto(id);
+  }
+
+  /// Promote Chat Member
+  ///
+  /// This method will promote the chat member in the current context.
+  Future<bool> promoteAuthor({
+    bool? isAnonymous,
+    bool? canManageChat,
+    bool? canPostMessages,
+    bool? canEditMessages,
+    bool? canDeleteMessages,
+    bool? canManageVideoChats,
+    bool? canRestrictMembers,
+    bool? canPromoteMembers,
+    bool? canChangeInfo,
+    bool? canInviteUsers,
+    bool? canPinMessages,
+    bool? canManageTopics,
+  }) async {
+    return await api.promoteChatMember(
+      id,
+      update.message!.from!.id,
+      isAnonymous: isAnonymous,
+      canManageChat: canManageChat,
+      canPostMessages: canPostMessages,
+      canEditMessages: canEditMessages,
+      canDeleteMessages: canDeleteMessages,
+      canManageVideoChats: canManageVideoChats,
+      canRestrictMembers: canRestrictMembers,
+      canPromoteMembers: canPromoteMembers,
+      canChangeInfo: canChangeInfo,
+      canInviteUsers: canInviteUsers,
+      canPinMessages: canPinMessages,
+      canManageTopics: canManageTopics,
+    );
+  }
+
+  /// Restrict Chat Member
+  ///
+  /// This method will restrict the chat member in the current context.
+  Future<bool> restrictAuthor(
+    ChatPermissions permissions, {
+    DateTime? untilDate,
+  }) async {
+    return await api.restrictChatMember(
+      id,
+      update.message!.from!.id,
+      permissions,
+      untilDate: untilDate,
+    );
+  }
+
+  /// Export Chat Invite Link
+  ///
+  /// This method will export the chat invite link in the current context.
+  Future<String> exportChatInviteLink() async {
+    return await api.exportChatInviteLink(id);
+  }
+
+  /// Revoke Chat Invite Link
+  ///
+  /// This method will revoke the chat invite link in the current context.
+  Future<ChatInviteLink> revokeChatInviteLink(String link) async {
+    return await api.revokeChatInviteLink(id, link);
+  }
+
+  /// Pin Chat Message
+  ///
+  /// This method will pin the chat message in the current context.
+  Future<bool> pinChatMessage({
+    bool? disableNotification,
+  }) async {
+    return await api.pinChatMessage(
+      id,
+      update.message!.messageId,
+      disableNotification: disableNotification,
+    );
+  }
+
+  /// Unpin Chat Message
+  ///
+  /// This method will unpin the chat message in the current context.
+  Future<bool> unpinChatMessage(int messageId) async {
+    return await api.unpinChatMessage(
+      id,
+      messageId,
+    );
+  }
+
+  /// Get Chat
+  ///
+  /// This method will get the chat in the current context.
+  Future<Chat> getChat() async {
+    return await api.getChat(id);
+  }
+
+  /// Get Chat Administrators
+  ///
+  /// This method will get the chat administrators in the current context.
+  Future<List<ChatMember>> getChatAdministrators() async {
+    return await api.getChatAdministrators(id);
+  }
+
+  /// Get Chat Member
+  ///
+  /// This method will get the chat member in the current context.
+  Future<ChatMember> getChatMember(int userId) async {
+    return await api.getChatMember(id, userId);
+  }
+
+  /// Leave Chat
+  ///
+  /// This method will leave the chat in the current context.
+  Future<bool> leaveChat() async {
+    return await api.leaveChat(id);
+  }
+}

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -1,5 +1,13 @@
 part of televerse;
 
+/// Mixin for sending messages.
+///
+/// This mixin contains methods for sending messages to the user.
+/// That includes methods like [reply], [replyWithPhoto], [replyWithAudio],
+/// [replyWithDocument], [replyWithVideo], [replyWithAnimation], [replyWithVoice],
+/// [replyWithVideoNote], [replyWithMediaGroup], [replyWithLocation], [replyWithVenue],
+/// [replyWithContact], [replyWithDice], [replyWithPoll], [replyWithChatAction],
+/// [replyWithGame], [replyWithSticker],
 mixin MessageMixin on Context {
   /// Reply a Text Message to the user.
   Future<Message> reply(

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -573,4 +573,74 @@ mixin MessageMixin on Context {
       update.message!.messageId,
     );
   }
+
+  /// Edit the caption of a message.
+  ///
+  /// This method can be used to edit captions of the message in the current context.
+  Future<Message> editMessageCaption(
+    String caption, {
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    InlineKeyboardMarkup? replyMarkup,
+  }) async {
+    return await api.editMessageCaption(
+      id,
+      update.message!.messageId,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Edit message live location
+  ///
+  /// This method will edit the message live location in the current context.
+  Future<MessageOrBoolean> editMessageLiveLocation({
+    String? inlineMessageId,
+    double? latitude,
+    double? longitude,
+    double? horizontalAccuracy,
+    int? heading,
+    int? proximityAlertRadius,
+    InlineKeyboardMarkup? replyMarkup,
+  }) async {
+    return await api.editMessageLiveLocation(
+      id,
+      update.message!.messageId,
+      inlineMessageId: inlineMessageId,
+      latitude: latitude,
+      longitude: longitude,
+      horizontalAccuracy: horizontalAccuracy,
+      heading: heading,
+      proximityAlertRadius: proximityAlertRadius,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Forward the message.
+  ///
+  /// This method will forward the message in the current context.
+  Future<Message> forwardMessage(
+    ID chatId, {
+    bool? disableNotification,
+    int? messageThreadId,
+    bool? protectContent,
+  }) async {
+    return await api.forwardMessage(
+      chatId,
+      id,
+      update.message!.messageId,
+      messageThreadId: messageThreadId,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+    );
+  }
+
+  /// Get Author
+  ///
+  /// This method will get the chat member in the current context.
+  Future<ChatMember> getAuthor(int userId) async {
+    return await api.getChatMember(id, update.message!.from!.id);
+  }
 }

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -302,4 +302,244 @@ mixin MessageMixin on Context {
       replyMarkup: replyMarkup,
     );
   }
+
+  /// Reply with a Venue to the user.
+  ///
+  /// Provide a [latitude], a [longitude], a [title] and an [address] to send a venue.
+  Future<Message> replyWithVenue(
+    double latitude,
+    double longitude,
+    String title,
+    String address, {
+    int? messageThreadId,
+    String? foursquareId,
+    String? foursquareType,
+    String? googlePlaceId,
+    String? googlePlaceType,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendVenue(
+      id,
+      latitude,
+      longitude,
+      title,
+      address,
+      messageThreadId: messageThreadId,
+      foursquareId: foursquareId,
+      foursquareType: foursquareType,
+      googlePlaceId: googlePlaceId,
+      googlePlaceType: googlePlaceType,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Contact to the user.
+  ///
+  /// Provide a [phoneNumber], a [firstName] and an [lastName] to send a contact.
+  Future<Message> replyWithContact(
+    String phoneNumber,
+    String firstName, {
+    int? messageThreadId,
+    String? lastName,
+    String? vcard,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendContact(
+      id,
+      phoneNumber,
+      firstName,
+      lastName: lastName,
+      messageThreadId: messageThreadId,
+      vcard: vcard,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Poll to the user.
+  ///
+  /// Provide a [question], a list of [options] and a [type] to send a poll.
+  Future<Message> replyWithPoll(
+    String question,
+    List<String> options, {
+    int? messageThreadId,
+    bool? isAnonymous,
+    PollType type = PollType.regular,
+    bool? allowsMultipleAnswers,
+    int? correctOptionId,
+    String? explanation,
+    ParseMode? explanationParseMode,
+    List<MessageEntity>? explanationEntities,
+    int? openPeriod,
+    DateTime? closeDate,
+    bool? isClosed,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendPoll(
+      id,
+      question,
+      options,
+      messageThreadId: messageThreadId,
+      isAnonymous: isAnonymous,
+      type: type,
+      allowsMultipleAnswers: allowsMultipleAnswers,
+      correctOptionId: correctOptionId,
+      explanation: explanation,
+      explanationParseMode: explanationParseMode,
+      explanationEntities: explanationEntities,
+      openPeriod: openPeriod,
+      closeDate: closeDate,
+      isClosed: isClosed,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Dice to the user.
+  ///
+  /// Provide a [emoji] to send a dice.
+  Future<Message> replyWithDice({
+    DiceEmoji emoji = DiceEmoji.dice,
+    int? messageThreadId,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendDice(
+      id,
+      emoji: emoji,
+      messageThreadId: messageThreadId,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Chat Action to the user.
+  ///
+  /// Provide a [action] to send a chat action.
+  Future<bool> replyWithChatAction(
+    ChatAction action, {
+    int? messageThreadId,
+  }) async {
+    return await api.sendChatAction(
+      id,
+      action,
+      messageThreadId: messageThreadId,
+    );
+  }
+
+  /// Reply with a Game to the user.
+  ///
+  /// Provide a [shortName] to send a game.
+  Future<Message> replyWithGame(
+    String shortName, {
+    int? messageThreadId,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendGame(
+      id,
+      shortName,
+      messageThreadId: messageThreadId,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with an Animation to the user.
+  ///
+  /// Provide an [animation] to send an animation.
+  Future<Message> replyWithAnimation(
+    InputFile animation, {
+    int? messageThreadId,
+    int? duration,
+    int? width,
+    int? height,
+    InputFile? thumb,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    bool? hasSpoiler,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendAnimation(
+      id,
+      animation,
+      messageThreadId: messageThreadId,
+      duration: duration,
+      width: width,
+      height: height,
+      thumb: thumb,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      hasSpoiler: hasSpoiler,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Sticker to the user.
+  ///
+  /// Provide a [sticker] to send a sticker.
+  Future<Message> replyWithSticker(
+    InputFile sticker, {
+    String? messageThreadId,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    InlineKeyboardMarkup? replyMarkup,
+  }) async {
+    return await api.sendSticker(
+      id,
+      sticker,
+      messageThreadId: messageThreadId,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
 }

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -28,4 +28,278 @@ mixin MessageMixin on Context {
       replyMarkup: replyMarkup,
     );
   }
+
+  /// Reply with a Photo to the user.
+  ///
+  /// Provide an [InputFile] as [photo]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  ///
+  /// Example:
+  /// ```dart
+  /// ctx.replyPhoto(InputFile.fromFile(File("photo.jpg")));
+  /// ```
+  Future<Message> replyWithPhoto(
+    InputFile photo, {
+    int? messageThreadId,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendPhoto(
+      id,
+      photo,
+      messageThreadId: messageThreadId,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with an Audio to the user.
+  ///
+  /// Provide an [InputFile] as [audio]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  Future<Message> replyWithAudio(
+    InputFile audio, {
+    int? messageThreadId,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    int? duration,
+    String? performer,
+    String? title,
+    InputFile? thumb,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendAudio(
+      id,
+      audio,
+      messageThreadId: messageThreadId,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      duration: duration,
+      performer: performer,
+      title: title,
+      thumb: thumb,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Document to the user.
+  ///
+  /// Provide an [InputFile] as [document]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  Future<Message> replyWithDocument(
+    InputFile document, {
+    int? messageThreadId,
+    InputFile? thumb,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    bool? disableContentTypeDetection,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendDocument(
+      id,
+      document,
+      messageThreadId: messageThreadId,
+      thumb: thumb,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      disableContentTypeDetection: disableContentTypeDetection,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Video to the user.
+  ///
+  /// Provide an [InputFile] as [video]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  Future<Message> replyWithVideo(
+    InputFile video, {
+    int? messageThreadId,
+    int? duration,
+    int? width,
+    int? height,
+    InputFile? thumb,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    bool? hasSpoiler,
+    bool? supportsStreaming,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendVideo(
+      id,
+      video,
+      messageThreadId: messageThreadId,
+      duration: duration,
+      width: width,
+      height: height,
+      thumb: thumb,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      hasSpoiler: hasSpoiler,
+      supportsStreaming: supportsStreaming,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Video Note to the user.
+  ///
+  /// Provide an [InputFile] as [videoNote]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  Future<Message> replyWithVideoNote(
+    InputFile videoNote, {
+    int? messageThreadId,
+    int? duration,
+    int? length,
+    InputFile? thumb,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendVideoNote(
+      id,
+      videoNote,
+      messageThreadId: messageThreadId,
+      duration: duration,
+      length: length,
+      thumb: thumb,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Voice to the user.
+  ///
+  /// Provide an [InputFile] as [voice]. Use the [InputFile.fromFile] or [InputFile.fromUrl] or [InputFile.fromFileId]
+  /// constructors to create an [InputFile] from a file or a URL or a file ID.
+  Future<Message> replyWithVoice(
+    InputFile voice, {
+    int? messageThreadId,
+    String? caption,
+    ParseMode? parseMode,
+    List<MessageEntity>? captionEntities,
+    int? duration,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendVoice(
+      id,
+      voice,
+      messageThreadId: messageThreadId,
+      caption: caption,
+      parseMode: parseMode,
+      captionEntities: captionEntities,
+      duration: duration,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Reply with a Media Group to the user.
+  ///
+  /// Provide a list of [InputMedia] as [media]. Use the [InputMedia.fromFile] or [InputMedia.fromUrl] or [InputMedia.fromFileId]
+  /// constructors to create an [InputMedia] from a file or a URL or a file ID.
+  Future<List<Message>> replyWithMediaGroup(
+    List<InputMedia> media, {
+    int? messageThreadId,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+  }) async {
+    return await api.sendMediaGroup(
+      id,
+      media,
+      messageThreadId: messageThreadId,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+    );
+  }
+
+  /// Reply with a Location to the user.
+  ///
+  /// Provide a [latitude] and a [longitude] to send a location.
+  Future<Message> replyWithLocation(
+    double latitude,
+    double longitude, {
+    int? messageThreadId,
+    double? horizontalAccuracy,
+    int? livePeriod,
+    int? heading,
+    int? proximityAlertRadius,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendLocation(
+      id,
+      latitude,
+      longitude,
+      messageThreadId: messageThreadId,
+      horizontalAccuracy: horizontalAccuracy,
+      livePeriod: livePeriod,
+      heading: heading,
+      proximityAlertRadius: proximityAlertRadius,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
 }

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -542,4 +542,35 @@ mixin MessageMixin on Context {
       replyMarkup: replyMarkup,
     );
   }
+
+  /// Edit the text of a message.
+  ///
+  /// This method can be used to edit text of messages sent by the bot.
+  Future<Message> editMessageText(
+    String text, {
+    ParseMode? parseMode,
+    List<MessageEntity>? entities,
+    bool disableWebPagePreview = false,
+    InlineKeyboardMarkup? replyMarkup,
+  }) async {
+    return await api.editMessageText(
+      id,
+      update.message!.messageId,
+      text,
+      parseMode: parseMode,
+      entities: entities,
+      disableWebPagePreview: disableWebPagePreview,
+      replyMarkup: replyMarkup,
+    );
+  }
+
+  /// Delete the message.
+  ///
+  /// Use this method to delete the message received by the bot.
+  Future<bool> deleteMessage() async {
+    return await api.deleteMessage(
+      id,
+      update.message!.messageId,
+    );
+  }
 }

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -1,0 +1,31 @@
+part of televerse;
+
+mixin MessageMixin on Context {
+  /// Reply a Text Message to the user.
+  Future<Message> reply(
+    String text, {
+    int? messageThreadId,
+    ParseMode? parseMode,
+    List<MessageEntity>? entities,
+    bool? disableWebPagePreview,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendMessage(
+      id,
+      text,
+      messageThreadId: messageThreadId,
+      parseMode: parseMode,
+      entities: entities,
+      disableWebPagePreview: disableWebPagePreview,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+}

--- a/lib/src/televerse/models/message_or_boolean.dart
+++ b/lib/src/televerse/models/message_or_boolean.dart
@@ -1,5 +1,12 @@
 part of televerse.models;
 
+/// **Message or Boolean**
+///
+/// This class is used to represent a message or a boolean.
+/// There are some methods in the Telegram API that can return either a message or a boolean. To represent this, we use this class.
+/// For example [Televerse.editMessageLiveLocation], [Televerse.stopMessageLiveLocation] are methods that can return either a message or a boolean depending on the parameters you pass.
+///
+/// This class is used to represent this.
 class MessageOrBoolean {
   Message? message;
   bool? boolean;
@@ -17,6 +24,13 @@ class MessageOrBoolean {
     }
   }
 
+  /// **Type**
+  ///
+  /// This getter returns the type of the [MessageOrBoolean] class.
+  ///
+  /// This can either be [MsgOrBool.boolean] or [MsgOrBool.message].
+  ///
+  /// This can be used to identify either [bool] or [Message] is returned from Telegram API.
   MsgOrBool get type {
     if (message != null) {
       return MsgOrBool.message;
@@ -26,6 +40,10 @@ class MessageOrBoolean {
   }
 }
 
+/// **Message or Boolean**
+///
+/// This enum is used to identify whether the [MessageOrBoolean] class contains a message or a boolean.
+/// The [MessageOrBoolean.type] getter returns this enum.
 enum MsgOrBool {
   boolean,
   message,

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -780,7 +780,7 @@ class Televerse extends Event {
   }
 
   /// Use this method to send a group of photos, videos, documents or audios as an album. Documents and audio files can be only grouped in an album with messages of the same type. On success, an array of Messages that were sent is returned.
-  Future<List<MessageContext>> sendMediaGroup(
+  Future<List<Message>> sendMediaGroup(
     ID chatId,
     List<InputMedia> media, {
     int? messageThreadId,
@@ -847,9 +847,7 @@ class Televerse extends Event {
         files,
         params,
       );
-      return (response)
-          .map((e) => MessageContext(this, Message.fromJson(e)))
-          .toList();
+      return (response).map((e) => Message.fromJson(e)).toList();
     }
 
     params["media"] = jsonEncode(media.map((m) => m.toJson()).toList());
@@ -857,9 +855,7 @@ class Televerse extends Event {
     List<dynamic> response = await HttpClient.getURI(
       _buildUri("sendMediaGroup", params),
     );
-    return (response)
-        .map((e) => MessageContext(this, Message.fromJson(e)))
-        .toList();
+    return (response).map((e) => Message.fromJson(e)).toList();
   }
 
   /// Use this method to send point on the map. On success, the sent Message is returned.

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -1605,9 +1605,9 @@ class Televerse extends Event {
   /// Use this method to add a message to the list of pinned messages in a chat. If the chat is not a private chat, the bot must be an administrator in the chat for this to work and must have the 'can_pin_messages' administrator right in a supergroup or 'can_edit_messages' administrator right in a channel. Returns True on success.
   Future<bool> pinChatMessage(
     ID chatId,
-    int messageId,
+    int messageId, {
     bool? disableNotification,
-  ) async {
+  }) async {
     Map<String, dynamic> params = {
       "chat_id": chatId.id,
       "message_id": messageId,

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -24,6 +24,7 @@ part 'src/televerse/filters/filters.dart';
 part 'src/televerse/context/mixins/message_mixin.dart';
 part 'src/televerse/context/mixins/management.dart';
 part 'src/televerse/context/mixins/callback_mixin.dart';
+part 'src/televerse/context/mixins/inline_mixin.dart';
 
 /// The main class of the library.
 ///

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -21,6 +21,7 @@ part 'src/utils/date.dart';
 part 'src/utils/http.dart';
 part 'src/utils/utils.dart';
 part 'src/televerse/filters/filters.dart';
+part 'src/televerse/context/mixins/message_mixin.dart';
 
 /// The main class of the library.
 ///

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -23,6 +23,7 @@ part 'src/utils/utils.dart';
 part 'src/televerse/filters/filters.dart';
 part 'src/televerse/context/mixins/message_mixin.dart';
 part 'src/televerse/context/mixins/management.dart';
+part 'src/televerse/context/mixins/callback_mixin.dart';
 
 /// The main class of the library.
 ///

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -22,6 +22,7 @@ part 'src/utils/http.dart';
 part 'src/utils/utils.dart';
 part 'src/televerse/filters/filters.dart';
 part 'src/televerse/context/mixins/message_mixin.dart';
+part 'src/televerse/context/mixins/management.dart';
 
 /// The main class of the library.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse is a Telegram Bot API Framework written completely in Dart. You can use this framework to create your own Telegram Bots, efficiently and easily.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
This PR comes with a lot of changes in Context.

- Added `MessageMixin` to support `MessageContext`.
- Added `replyWithPhoto`, `replyWithVideo`, `replyWithAudio`, `replyWithDocument`, `replyWithVideoNote`, `replyWithVoice`, `replyWithVenue`, `replyWithContact`, `replyWithPoll`, `replyWithDice`, `replyWithChatAction`, `replyWithGame`, `replyWithAnimation`, `replyWithSticker`, `editMessageText`, and `deleteMessage` methods to `MessageContext`.
- Added `ManagementMixin` to support `MessageContext`.
- Added `banAuthor`, `banSenderChat`, `deleteChatPhoto`, `promoteAuthor`, `restrictAuthor`, `exportChatInviteLink`, `revokeChatInviteLink`, `pinChatMessage`, `unpinChatMessage`, `getChat`, `getChatAdministrators`, `getChatMember`, and `leaveChat` on `ManagementMixin`.
- Both `MessageMixin` and `ManagementMixin` are now available on `MessageContext`.
- Added `CallbackQueryMixin` to support `CallbackQueryContext`.
- `CallbackQueryContext` now has `answer` and `editMessage` methods available.
- Added `InlineQueryMixin` to support `InlineQueryContext`.
- `InlineQueryContext` now has `answer`, and `answerWithArticles` methods available.

:)