### PR TITLE
Chat from ChatID & Bot instance anywhere 🦉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.6
+- Added `Televerse.instance` getter to get the last instance of `Bot` created.
+- Added `ChatID.chat` getter to get the `Chat` object from the `ChatID` object.
+- Added optional `RegExp? regex` parameter to `Televerse.command` method.
 ## 1.2.5
 - Added `startParameter` getter to `MessageContext` class. This will be automatically set when the bot is started by a user clicking on a deep link such as `t.me/MyBot?start=12345`.
 - Added more tests.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ bot.command('start', (ctx) {
 ## 📚 Documentation
 
 ### 📖 Televerse Wiki
-We a dedicated documentation on GitHub Wiki on this repo. Check it our here: [Televerse Wiki](https://github.com/HeySreelal/televerse/wiki).
+We have a dedicated documentation on GitHub Wiki on this repo. Check it our here: [Televerse Wiki](https://github.com/HeySreelal/televerse/wiki).
 
-### In simple words
+### ✨ In simple words
 
 You can access the whole Telegram Bot API methods with the `bot` instance. Or if you're inside a `MessageContext` you can access the same with `ctx.api`
 

--- a/lib/src/televerse/event/event.dart
+++ b/lib/src/televerse/event/event.dart
@@ -218,16 +218,22 @@ class Event {
   /// ```
   ///
   /// This will reply "Hello!" to any message that starts with `/start`.
+  ///
+  /// Optionally, you can specify a [pattern] to match the command with. If the command matches the pattern, the [MessageContext.matches] will be set to the matches.
   void command(
     String command,
-    FutureOr<void> Function(MessageContext ctx) callback,
-  ) {
+    FutureOr<void> Function(MessageContext ctx) callback, {
+    RegExp? pattern,
+  }) {
     onMessage.listen((MessageContext context) {
       if (context.message.text == null) return;
       if (context.message.text!.startsWith('/$command')) {
         if (command == 'start' && context.message.text!.split(' ').length > 1) {
           context.startParameter =
               context.message.text!.split(' ').sublist(1).join(' ');
+        }
+        if (pattern != null) {
+          context.matches = pattern.allMatches(context.message.text!).toList();
         }
 
         callback(context);
@@ -394,5 +400,14 @@ class Event {
         callback(context);
       }
     });
+  }
+
+  /// Registers a callback for inline queries.
+  ///
+  /// The callback will be called when an inline query with the specified query is received.
+  void inlineQuery(
+    FutureOr<void> Function(InlineQueryContext ctx) callback,
+  ) {
+    onInlineQuery.listen(callback);
   }
 }

--- a/lib/src/televerse/models/chat_id.dart
+++ b/lib/src/televerse/models/chat_id.dart
@@ -35,6 +35,8 @@ class ChatID extends ID {
   factory ChatID.create(int id) {
     return ChatID(id);
   }
+
+  Future<Chat> get chat => Televerse.instance.getChat(this);
 }
 
 /// **ChannelID**

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -17,6 +17,27 @@ part of televerse;
 ///
 /// The [Televerse] class extends [Event] class. The [Event] class is used to emit events and additionally provides a bunch of useful methods.
 class Televerse extends Event with OnEvent {
+  static late String _botToken;
+
+  /// Get the bot instance.
+  ///
+  /// This getter returns the bot instance. You can use this to access the bot instance from anywhere in your code.
+  ///
+  /// Notes:
+  ///   - If you try to access this getter before creating a bot instance, it will throw an error.
+  ///   - The instance will be the last created bot instance.
+  ///   - DO NOT use this getter to create a bot instance. Use the [Televerse] constructor instead. This getter is only used to access the bot instance.
+  static Televerse get instance {
+    try {
+      return Televerse(_botToken);
+    } catch (err) {
+      throw TeleverseException(
+        "Bot instance not found. ",
+        "Create a Bot instance with a token first.",
+      );
+    }
+  }
+
   final String token;
 
   late Fetcher fetcher;
@@ -26,6 +47,7 @@ class Televerse extends Event with OnEvent {
     Fetcher? fetcher,
   }) {
     this.fetcher = fetcher ?? LongPolling(this);
+    _botToken = token;
   }
 
   final String _baseUrl = "api.telegram.org";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse is a Telegram Bot API Framework written completely in Dart. You can use this framework to create your own Telegram Bots, efficiently and easily.
-version: 1.2.5
+version: 1.2.6
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
Changes:
- Added `Televerse.instance` getter to get the last instance of `Bot` created.
- Added `ChatID.chat` getter to get the `Chat` object from the `ChatID` object.
- Added optional `RegExp? regex` parameter to `Televerse.command` method.