### PR TITLE
Shorthand handlers are added 😎

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1 
+- Added shorthand methods to setup listners for `/start`, `/help`, `/settings` commands.
+- You can now use `Televerse.start`, `Televerse.help`, and `Televerse.settings` to listen for these commands.
+- All these methods accepts a `MessageHandler` as a parameter which is a type alias for `FutureOr<void> Function(MessageContext)`.
+- Added `MessageHandler`, `CallbackQueryHandler`, and `InlineQueryHandler` type aliases.
 ## 1.3.0
 - Telegram Bot API 6.5 (February 3, 2023)
 - This includes addition of classes like `KeyboardButtonRequestUser`, `KeyboardButtonRequestChat`, `UserShared` and `ChatShared`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,6 @@
-Copyright 2022 - Sreelal TS
-
+Copyright (c) 2020 Sreelal TS. All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,34 @@ import 'package:televerse/televerse.dart';
 Bot bot = Bot('YOUR_BOT_TOKEN');
 
 ```
-Now with the bot instance you can start listening for updates:
+Now with the bot instance you can start listening for updates such as messages, commands, etc.
+
+To start polling updates from Telegram servers, you need to call:
+
+```dart
+bot.start()
+````
+
+
+
+From, Televerse 1.3.1, you can use `bot.start` method to start listening for updates and also, setup a command listener for the `/start` command.
+
+That is you can shrink this code:
 
 ```dart
 bot.command('start', (ctx) {
   ctx.reply('Hello, World!');
 });
 
+bot.start();
+```
+
+To this:
+
+```dart
+bot.start((ctx) {
+  ctx.reply('Hello, World!');
+});
 ```
 
 ## 📚 Documentation

--- a/example/televerse_example.dart
+++ b/example/televerse_example.dart
@@ -27,7 +27,6 @@ void main() {
   });
 
   // Listen to commands
-  bot.command("start", (ctx) => ctx.reply("Hello!"));
   bot.command("bye", (ctx) => ctx.reply("Bye!"));
 
   // Add advanced filters to particularly listen to messages
@@ -60,5 +59,9 @@ void main() {
     ctx.reply("This will only be executed if the message has text");
   });
 
-  bot.start();
+  // Since v1.3.1 you can listen for `/start`, `/help` and `/settings` commands
+  // in an easier way.
+  bot.start((ctx) => ctx.reply("Hello!"));
+  bot.settings((ctx) => ctx.reply("Settings"));
+  bot.help((ctx) => ctx.reply("Help"));
 }

--- a/lib/src/televerse/event/event.dart
+++ b/lib/src/televerse/event/event.dart
@@ -222,7 +222,7 @@ class Event {
   /// Optionally, you can specify a [pattern] to match the command with. If the command matches the pattern, the [MessageContext.matches] will be set to the matches.
   void command(
     String command,
-    FutureOr<void> Function(MessageContext ctx) callback, {
+    MessageHandler callback, {
     RegExp? pattern,
   }) {
     onMessage.listen((MessageContext context) {
@@ -256,7 +256,7 @@ class Event {
   /// This will answer "Hello!" to any callback query that has the data "start".
   void callbackQuery(
     String data,
-    FutureOr<void> Function(CallbackQueryContext ctx) callback, {
+    CallbackQueryHandler callback, {
     RegExp? regex,
   }) {
     onCallbackQuery.listen((CallbackQueryContext context) {
@@ -292,7 +292,7 @@ class Event {
   /// the [chatTypes] method.
   void chatType(
     ChatType type,
-    FutureOr<void> Function(MessageContext ctx) callback,
+    MessageHandler callback,
   ) {
     onMessage.listen((MessageContext context) {
       if (context.message.chat.type == type) {
@@ -319,7 +319,7 @@ class Event {
   /// from a private chat or a group.
   void chatTypes(
     List<ChatType> types,
-    FutureOr<void> Function(MessageContext ctx) callback,
+    MessageHandler callback,
   ) {
     onMessage.listen((MessageContext context) {
       if (types.contains(context.message.chat.type)) {
@@ -343,7 +343,7 @@ class Event {
   /// ```
   void filter(
     bool Function(MessageContext ctx) predicate,
-    FutureOr<void> Function(MessageContext ctx) callback,
+    MessageHandler callback,
   ) {
     onMessage.listen((MessageContext context) {
       if (predicate(context)) {
@@ -364,7 +364,7 @@ class Event {
   /// ```
   void text(
     String text,
-    FutureOr<void> Function(MessageContext ctx) callback,
+    MessageHandler callback,
   ) {
     onMessage.listen((MessageContext context) {
       if (context.message.text?.contains(text) ?? false) {
@@ -391,7 +391,7 @@ class Event {
   /// matches the regular expression `Hello, (.*)!`.
   void hears(
     RegExp exp,
-    FutureOr<void> Function(MessageContext ctx) callback,
+    MessageHandler callback,
   ) {
     onMessage.listen((MessageContext context) {
       final matches = exp.allMatches(context.message.text ?? '');
@@ -406,8 +406,18 @@ class Event {
   ///
   /// The callback will be called when an inline query with the specified query is received.
   void inlineQuery(
-    FutureOr<void> Function(InlineQueryContext ctx) callback,
+    InlineQueryHandler Function(InlineQueryContext ctx) callback,
   ) {
     onInlineQuery.listen(callback);
+  }
+
+  /// Registers a callback for the `/settings` command.
+  void settings(MessageHandler handler) async {
+    command("settings", handler);
+  }
+
+  /// Registers a callback for the `/help` command.
+  void help(MessageHandler handler) async {
+    command("help", handler);
   }
 }

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -69,11 +69,16 @@ class Televerse extends Event with OnEvent {
   }
 
   /// Start polling for updates.
-  Future<void> start() async {
+  Future<void> start([FutureOr<void> Function(MessageContext)? handler]) async {
     fetcher.start();
     fetcher.onUpdate().listen((update) {
       _onUpdate(update);
     });
+
+    // Registers a handler to listen for /start command
+    if (handler != null) {
+      command("start", handler);
+    }
   }
 
   /// Stream of [Update] objects.

--- a/lib/src/types/aliases.dart
+++ b/lib/src/types/aliases.dart
@@ -1,0 +1,17 @@
+part of televerse;
+
+/// [MessageHandler] is a type alias for a function that takes a [MessageContext] as parameter and returns a [FutureOr] of [void].
+///
+/// This is used to define a callback function for almost all the methods that listen to messages.
+typedef MessageHandler = FutureOr<void> Function(MessageContext ctx);
+
+/// [CallbackQueryHandler] is a type alias for a function that takes a [CallbackQueryContext] as parameter and returns a [FutureOr] of [void].
+///
+/// This is used to define a callback function for almost all the methods that listen to callback queries.
+typedef CallbackQueryHandler = FutureOr<void> Function(
+    CallbackQueryContext ctx);
+
+/// [InlineQueryHandler] is a type alias for a function that takes a [InlineQueryContext] as parameter and returns a [FutureOr] of [void].
+///
+/// This is used to define a callback function for almost all the methods that listen to inline queries.
+typedef InlineQueryHandler = FutureOr<void> Function(InlineQueryContext ctx);

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -22,6 +22,9 @@ part 'src/utils/utils.dart';
 part 'src/televerse/markups/keyboard.dart';
 part 'src/televerse/markups/inline_keyboard.dart';
 
+/// Type aliases for the library.
+part 'src/types/aliases.dart';
+
 /// The main class of the library.
 ///
 /// This class is used to create a new bot instance. This is just a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.5!
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
Now it's way more easy to setup listeners for common commands like: `/start`, `/help`, or `/settings`

Here's how to:

```dart
  bot.start((ctx) => ctx.reply("Hello!"));
  bot.settings((ctx) => ctx.reply("Settings"));
  bot.help((ctx) => ctx.reply("Help"));
```

