### PR TITLE
Fetcher config is updated! 🙋🏻‍♂️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.4.2
 - Fixed an issue with the webhook configuration.
+- Made it easier to set a custom fetcher. You don't have to pass the `RawAPI` instance to the `Fetcher` constructor anymore.
 ## 1.4.1
 - Minor formatting changes.
 ## 1.4.0

--- a/example/televerse_example.dart
+++ b/example/televerse_example.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 
 import 'package:televerse/televerse.dart';
 
-void main() {
+void main() async {
   final String token = Platform.environment["BOT_TOKEN"]!;
 
-  Bot bot = Bot(token);
+  Bot bot = Bot(token, fetcher: LongPolling());
 
   // Note: You can use the [onMessage] getter to listen to all messages
   //     or use the [onCommand] getter to listen to commands

--- a/lib/src/televerse/fetch/fetch.dart
+++ b/lib/src/televerse/fetch/fetch.dart
@@ -12,8 +12,10 @@ part 'webhook.dart';
 /// **Fetcher** - This is the base class for all fetchers. It is used to fetch updates from the Telegram API.
 /// You can use this class to create your own fetcher. Currently, there are two fetchers: [LongPolling] and [Webhook].
 abstract class Fetcher {
+  /// The stream controller that emits new updates.
   final StreamController<Update> _updateStreamController;
 
+  /// Creates a new fetcher.
   Fetcher() : _updateStreamController = StreamController.broadcast();
 
   /// Emit new update into the stream.
@@ -27,4 +29,12 @@ abstract class Fetcher {
 
   /// Stops fetching updates.
   Future<void> stop();
+
+  /// Raw API instance.
+  late final RawAPI api;
+
+  void setApi(RawAPI api) {
+    this.api = api;
+    print('Fetcher: API set!');
+  }
 }

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -3,7 +3,6 @@ part of televerse.fetch;
 /// A class that handles long polling.
 /// This class is used to fetch updates from the Telegram API. It uses the long polling method.
 class LongPolling extends Fetcher {
-  final Televerse televerse;
   int offset;
   final int timeout;
   final int limit;
@@ -14,8 +13,7 @@ class LongPolling extends Fetcher {
   bool _isPolling = false;
   bool get isPolling => _isPolling;
 
-  LongPolling(
-    this.televerse, {
+  LongPolling({
     this.offset = 0,
     this.timeout = 30,
     this.limit = 100,
@@ -54,7 +52,7 @@ class LongPolling extends Fetcher {
   Future<void> _poll() async {
     if (!_isPolling) return;
     try {
-      final updates = await televerse.api.getUpdates(
+      final updates = await api.getUpdates(
         offset: offset,
         limit: limit,
         timeout: timeout,

--- a/lib/src/televerse/fetch/webhook.dart
+++ b/lib/src/televerse/fetch/webhook.dart
@@ -2,9 +2,6 @@ part of televerse.fetch;
 
 /// This class is used to create a webhook fetcher. It is a subclass of [Fetcher].
 class Webhook extends Fetcher {
-  /// Raw API instance.
-  final RawAPI api;
-
   /// Http server instance.
   final io.HttpServer _server;
 
@@ -66,7 +63,6 @@ class Webhook extends Fetcher {
   /// Throws `WebhookException.failedToSetWebhook` if the webhook failed to set.
   Webhook(
     this._server, {
-    required this.api,
     required this.url,
     this.ipAddress,
     this.secretPath = '',

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -70,7 +70,8 @@ class Televerse extends Event with OnEvent {
     Fetcher? fetcher,
     super.sync,
   }) {
-    this.fetcher = fetcher ?? LongPolling(this);
+    this.fetcher = fetcher ?? LongPolling();
+    this.fetcher.setApi(api);
     _botToken = token;
   }
 


### PR DESCRIPTION
Users now don't have to pass the `RawAPI` or `Televerse` instance to the Fetcher constructor anymore. The thought that since the user is already passing the `token` why can't we just use it to construct the `RawAPI` on our side ended up here.

Now, everything is as simple as:

```dart
  Bot bot = Bot(token, fetcher: LongPolling());
```

Or with a webhook like this:
```dart
  Bot bot = Bot(token, fetcher: Webhook(_server, url: url));
```