### PR TITLE
File helper methods 🔐

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.3
+- Added helper methods on `File` class to get the file download URL, download URI, file bytes, and finally to download the file.
+- Added `File.download` method to download the file.
+- Added `File.getDownloadUrl` method to get the file download URL as `String`.
+- Added `File.getDownloadURI` method to get the `Uri` object of the file download URL.
+- Added `File.getBytes` method to get the file bytes this returns a `Future<Uint8List>`.
+- Added `File.download` method to download the file. This returns a `Future<io.File>` object.
+- The working example is available at [examples/file_download.dart](./example/file_download.dart)
 ## 1.4.2
 - Fixed an issue with the webhook configuration.
 - Made it easier to set a custom fetcher. You don't have to pass the `RawAPI` instance to the `Fetcher` constructor anymore.

--- a/example/file_download.dart
+++ b/example/file_download.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:televerse/televerse.dart';
+
+void main() {
+  final Bot bot = Bot(Platform.environment["BOT_TOKEN"]!);
+
+  bot.on(TeleverseEvent.audio, (ctx) async {
+    ctx as MessageContext;
+    final aud = ctx.message.audio;
+    final file = await ctx.api.getFile(aud!.fileId);
+    // you can now get file bytes using
+    // await file.getBytes();
+    // or download it like:
+    await file.download();
+
+    ctx.reply("Done downloading file ${file.fileName}");
+  });
+
+  bot.start((ctx) {
+    ctx.reply("Send me an audio file");
+  });
+}

--- a/lib/src/telegram/models/file.dart
+++ b/lib/src/telegram/models/file.dart
@@ -107,5 +107,6 @@ class File {
     return await file.writeAsBytes(bytes);
   }
 
+  /// Returns the file name of the file.
   String get fileName => filePath.split("/").last;
 }

--- a/lib/src/telegram/models/file.dart
+++ b/lib/src/telegram/models/file.dart
@@ -3,23 +3,26 @@ part of models;
 /// This object represents a file ready to be downloaded. The file can be downloaded via the link https://api.telegram.org/file/bot<token>/<file_path>. It is guaranteed that the link will be valid for at least 1 hour. When the link expires, a new one can be requested by calling getFile.
 class File {
   /// Unique identifier for this file
-  String fileId;
+  final String fileId;
 
   /// Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
-  String fileUniqueId;
+  final String fileUniqueId;
 
   /// File size, if known
-  int fileSize;
+  final int fileSize;
 
   /// File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
-  String filePath;
+  final String filePath;
 
-  File(
-      {required this.fileId,
-      required this.fileUniqueId,
-      required this.fileSize,
-      required this.filePath});
+  /// Constructs the File object.
+  const File({
+    required this.fileId,
+    required this.fileUniqueId,
+    required this.fileSize,
+    required this.filePath,
+  });
 
+  /// Creates the File object from the given JSON model.
   factory File.fromJson(Map<String, dynamic> json) {
     return File(
       fileId: json['file_id'],
@@ -29,6 +32,7 @@ class File {
     );
   }
 
+  /// Returns the JSON representation of the File object.
   Map<String, dynamic> toJson() {
     return {
       'file_id': fileId,
@@ -37,4 +41,71 @@ class File {
       'file_path': filePath,
     }..removeWhere((key, value) => value == null);
   }
+
+  /// Returns the download URL for the particular file as [String]
+  ///
+  /// This method uses the latest Bot token used in your code. If you have multiple bots running with the same code, you might want to
+  /// pass the [token] parameter that can be used to generate the download URL.
+  String getDownloadUrl([String? token]) {
+    return 'https://api.telegram.org/file/bot${token ?? Televerse.instance.token}/$filePath';
+  }
+
+  /// Returns the [Uri] object of the download URL. This is an shorthand method for:
+  ///
+  /// ```dart
+  /// Uri.parse(file.getDownloadUrl())
+  /// ```
+  ///
+  /// Pass [token] parameter if you want to get the download url for a specific bot.
+  Uri getDownloadURI([String? token]) {
+    return Uri.parse(getDownloadUrl(token));
+  }
+
+  /// This is an advanced method in Televerse. This returns `Uint8List?` representing the byte data of the file.
+  ///
+  /// This method basically gets the file and decodes it's byte data. This can be very useful if you want to download the file or save it.
+  ///
+  /// Use the [token] parameter to specify the bot token to be used - if you're running multiple bots with the same code.
+  Future<Uint8List?> getBytes([String? token]) async {
+    try {
+      final r = await get(getDownloadURI(token));
+      if (r.statusCode == 200) {
+        return r.bodyBytes;
+      } else {
+        throw TeleverseException("Couldn't fetch the file data.");
+      }
+    } catch (err) {
+      return null;
+    }
+  }
+
+  /// This is an advanced method of Televerse. This method downloads the particular file and saves it to the
+  /// specified [path].
+  ///
+  /// Specify the [token] parameter if you want to use a specific bot token.
+  ///
+  /// Note: Make sure the [path] is a valid path and the directory exists.
+  Future<io.File?> download({String? path, String? token}) async {
+    path ??= io.Directory.current.path;
+
+    String fpath;
+    final name = filePath.split("/").last;
+    final ext = name.split(".").last;
+
+    final bytes = await getBytes(token);
+    if (bytes == null) return null;
+    if (path.endsWith(".$ext")) {
+      fpath = path;
+    } else {
+      fpath = "$path/$name";
+    }
+
+    final file = io.File(fpath);
+    if (!file.existsSync()) {
+      file.createSync();
+    }
+    return await file.writeAsBytes(bytes);
+  }
+
+  String get fileName => filePath.split("/").last;
 }

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -1,8 +1,11 @@
 library models;
 
 import 'dart:convert';
+import 'dart:typed_data';
 
+import 'package:http/http.dart';
 import 'package:televerse/televerse.dart';
+import 'dart:io' as io;
 
 import 'games.dart';
 import 'passport.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.5!
-version: 1.4.2
+version: 1.4.3
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
This update brings Televerse 1.4.3 with a bunch of helper methods on the `File` class.

- `File.download` method to download the file.
- `File.getDownloadUrl` method to get the file download URL as `String`.
- `File.getDownloadURI` method to get the `Uri` object of the file download URL.
- `File.getBytes` method to get the file bytes this returns a `Future<Uint8List>`.
- `File.download` method to download the file. This returns a `Future<io.File>` object.