### PR TITLE
Example, `entity` and event improvements. 🌈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.7
+- Added `Televerse.entity` method to listen to entities in messages.
+- Improved code quality.
+- Removed all the different StreamController classes and replaced them with a single `StreamController<Update>` instance.
+- All the event streams are now based on the `onUpdate` stream.
+- Added `Message.getEntityText` method to get the text of the entity.
+- Updated the [televerse_example](./example/televerse_example.dart) file to reflect the changes.
 ## 1.4.6
 - Added `Message.isCommand` getter to check if the message is a command.
 - Added `Televerse.onError` method to listen to unexpected exceptions.

--- a/example/televerse_example.dart
+++ b/example/televerse_example.dart
@@ -5,6 +5,7 @@ import 'package:televerse/televerse.dart';
 void main() async {
   final String token = Platform.environment["BOT_TOKEN"]!;
 
+  // Create a new bot instance
   Bot bot = Bot(token, fetcher: LongPolling());
 
   // Listen to commands
@@ -55,14 +56,20 @@ void main() async {
     // ctx will be of type [MessageContext]
     ctx as MessageContext;
     ctx.reply("This will be executed for every command");
+    ctx.reply(
+      "That really includes /start, /help and /settings and all other commands you define.",
+    );
 
     // Do your logic here
-    if (ctx.message.text == "televerse") {
+    if (ctx.message.text == "/televerse") {
       ctx.reply("Much love from Televerse! ❤️");
     }
   });
 
+  // You can also listen for particular message entities.
   bot.entity(MessageEntityType.mention, (ctx) {
-    ctx.reply("This will be executed for every mention");
+    ctx.reply(
+      "${ctx.message.getEntityText(MessageEntityType.mention)} was mentioned!",
+    );
   });
 }

--- a/example/televerse_example.dart
+++ b/example/televerse_example.dart
@@ -7,27 +7,8 @@ void main() async {
 
   Bot bot = Bot(token, fetcher: LongPolling());
 
-  // Note: You can use the [onMessage] getter to listen to all messages
-  //     or use the [onCommand] getter to listen to commands
-  bot.onMessage.listen((MessageContext ctx) async {
-    // Collect the ChatID from the context
-    // This one is actually from v1.0.0, starting from v1.1.0 you can use the [ctx.id] getter
-    final chatId = ChatID(ctx.chat.id);
-
-    // Send a message to the chat
-    await ctx.reply("Hello World!");
-
-    // And with the [api] getter you can access the Telegram API
-    await ctx.api.sendMessage(chatId, "Hello World!");
-
-    // Looking for a way to send a photo?
-    // You can use the [sendPhoto] method
-    final photo = InputFile.fromUrl("https://i.imgur.com/1Z1Z1Z1.jpg");
-    await ctx.api.sendPhoto(ctx.id, photo);
-  });
-
   // Listen to commands
-  bot.command("bye", (ctx) => ctx.reply("Bye!"));
+  bot.command("hello", (ctx) => ctx.reply("Hello!"));
 
   // Add advanced filters to particularly listen to messages
   bot.filter((ctx) => false, (ctx) {
@@ -36,7 +17,10 @@ void main() async {
 
   // Or you can do this:
   bool myAdvancedFilter(MessageContext ctx) {
-    return (ctx.message.photo?.last.fileSize ?? 0) > 1000000;
+    return ctx.message.photo?.any((photo) {
+          return photo.fileSize! > 1 * 1000 * 1024;
+        }) ??
+        false;
   }
 
   bot.filter(myAdvancedFilter, (ctx) {
@@ -48,7 +32,7 @@ void main() async {
   // The [bot.hears] method allows you to listen to messages that match a regular expression.
   // You can use the `MessageContext.matches` getter to access the matches of the regular expression.
   bot.hears(RegExp(r'Hello, (.*)!'), (ctx) {
-    ctx.reply('Hello, ${ctx.matches![1]}!');
+    ctx.reply('${ctx.matches![1]} must be a doing great!');
   });
 
   // With the [Bot.on] method you can listen for particular updates and you can
@@ -64,4 +48,21 @@ void main() async {
   bot.start((ctx) => ctx.reply("Hello!"));
   bot.settings((ctx) => ctx.reply("Settings"));
   bot.help((ctx) => ctx.reply("Help"));
+
+  // So with the [Bot.on] method you can listen for particular updates. Yeah, that indeed means
+  // that you can listen for all commands simply by listening for the [TeleverseEvent.command] event.
+  bot.on(TeleverseEvent.command, (ctx) {
+    // ctx will be of type [MessageContext]
+    ctx as MessageContext;
+    ctx.reply("This will be executed for every command");
+
+    // Do your logic here
+    if (ctx.message.text == "televerse") {
+      ctx.reply("Much love from Televerse! ❤️");
+    }
+  });
+
+  bot.entity(MessageEntityType.mention, (ctx) {
+    ctx.reply("This will be executed for every mention");
+  });
 }

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -543,5 +543,8 @@ class Message {
       : DateTime.fromMillisecondsSinceEpoch(forwardDate! * 1000);
 
   /// Returns [true] if the message is a command
-  bool get isCommand => text != null && text!.startsWith('/');
+  bool get isCommand => entities != null && entities!.isNotEmpty
+      ? entities!.first.type == MessageEntityType.botCommand &&
+          entities!.first.offset == 0
+      : false;
 }

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -3,229 +3,229 @@ part of models;
 /// This object represents a message.
 class Message {
   /// Unique message identifier inside this chat
-  int messageId;
+  final int messageId;
 
   /// Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
-  int? threadId;
+  final int? threadId;
 
   /// Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
-  int? messageThreadId;
+  final int? messageThreadId;
 
   /// Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
-  User? from;
+  final User? from;
 
   /// Optional. Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
-  Chat? senderChat;
+  final Chat? senderChat;
 
   /// Date the message was sent in Unix time
   ///
   /// Note: Handy [DateTime] object is available in [dateTime] getter.
-  int date;
+  final int date;
 
   /// Conversation the message belongs to
-  Chat chat;
+  final Chat chat;
 
   /// Optional. For forwarded messages, sender of the original message
-  User? forwardFrom;
+  final User? forwardFrom;
 
   /// Optional. For messages forwarded from channels or from anonymous administrators, information about the original sender chat
-  Chat? forwardFromChat;
+  final Chat? forwardFromChat;
 
   /// Optional. For messages forwarded from channels, identifier of the original message in the channel
-  int? forwardFromMessageId;
+  final int? forwardFromMessageId;
 
   /// Optional. For forwarded messages that were originally sent in channels or by an anonymous chat administrator, signature of the message sender if present
-  String? forwardSignature;
+  final String? forwardSignature;
 
   /// Optional. Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages
-  String? forwardSenderName;
+  final String? forwardSenderName;
 
   /// Optional. For forwarded messages, date the original message was sent in Unix time
   ///
   /// Note: Handy [DateTime] object is available in [forwardDateTime] getter.
-  int? forwardDate;
+  final int? forwardDate;
 
   /// Optional. True, if the message is sent to a forum topic
-  bool? isTopicMessage;
+  final bool? isTopicMessage;
 
   /// Optional. True, if the message is a channel post that was automatically forwarded to the connected discussion group
-  bool? isAutomaticForward;
+  final bool? isAutomaticForward;
 
   /// Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
-  Message? replyToMessage;
+  final Message? replyToMessage;
 
   /// Optional. Bot through which the message was sent
-  User? viaBot;
+  final User? viaBot;
 
   /// Optional. Date the message was last edited in Unix time
   ///
   /// Note: Handy [DateTime] object is available in [editDateTime] getter.
-  int? editDate;
+  final int? editDate;
 
   /// Optional. True, if the message can't be forwarded
-  bool? hasProtectedContent;
+  final bool? hasProtectedContent;
 
   /// Optional. The unique identifier of a media message group this message belongs to
-  String? mediaGroupId;
+  final String? mediaGroupId;
 
   /// Optional. Signature of the post author for messages in channels, or the custom title of an anonymous group administrator
-  String? authorSignature;
+  final String? authorSignature;
 
   /// Optional. For text messages, the actual UTF-8 text of the message
-  String? text;
+  final String? text;
 
   /// Optional. For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text
-  List<MessageEntity>? entities;
+  final List<MessageEntity>? entities;
 
   /// Optional. Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set
-  Animation? animation;
+  final Animation? animation;
 
   /// Optional. Message is an audio file, information about the file
-  Audio? audio;
+  final Audio? audio;
 
   /// Optional. Message is a general file, information about the file
-  Document? document;
+  final Document? document;
 
   /// Optional. Message is a photo, available sizes of the photo
-  List<PhotoSize>? photo;
+  final List<PhotoSize>? photo;
 
   /// Optional. Message is a sticker, information about the sticker
-  Sticker? sticker;
+  final Sticker? sticker;
 
   /// Optional. Message is a video, information about the video
-  Video? video;
+  final Video? video;
 
   /// Optional. Message is a video note, information about the video message
-  VideoNote? videoNote;
+  final VideoNote? videoNote;
 
   /// Optional. Message is a voice message, information about the file
-  Voice? voice;
+  final Voice? voice;
 
   /// Optional. Caption for the animation, audio, document, photo, video or voice
-  String? caption;
+  final String? caption;
 
   /// Optional. For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption
-  List<MessageEntity>? captionEntities;
+  final List<MessageEntity>? captionEntities;
 
   /// Optional. Message is a shared contact, information about the contact
-  Contact? contact;
+  final Contact? contact;
 
   /// Optional. Message is a dice with random value
-  Dice? dice;
+  final Dice? dice;
 
   /// Optional. Message is a game, information about the game. More about games »
-  Game? game;
+  final Game? game;
 
   /// Optional. Message is a native poll, information about the poll
-  Poll? poll;
+  final Poll? poll;
 
   /// Optional. Message is a venue, information about the venue. For backward compatibility, when this field is set, the location field will also be set
-  Venue? venue;
+  final Venue? venue;
 
   /// Optional. Message is a shared location, information about the location
-  Location? location;
+  final Location? location;
 
   /// Optional. New members that were added to the group or supergroup and information about them (the bot itself may be one of these members)
-  List<User>? newChatMembers;
+  final List<User>? newChatMembers;
 
   /// Optional. A member was removed from the group, information about them (this member may be the bot itself)
-  User? leftChatMember;
+  final User? leftChatMember;
 
   /// Optional. A chat title was changed to this value
-  String? newChatTitle;
+  final String? newChatTitle;
 
   /// Optional. A chat photo was change to this value
-  List<PhotoSize>? newChatPhoto;
+  final List<PhotoSize>? newChatPhoto;
 
   /// Optional. Service message: the chat photo was deleted
-  bool? deleteChatPhoto;
+  final bool? deleteChatPhoto;
 
   /// Optional. Service message: the group has been created
-  bool? groupChatCreated;
+  final bool? groupChatCreated;
 
   /// Optional. Service message: the supergroup has been created. This field can't be received in a message coming through updates, because bot can't be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
-  bool? supergroupChatCreated;
+  final bool? supergroupChatCreated;
 
   /// Optional. Service message: the channel has been created. This field can't be received in a message coming through updates, because bot can't be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
-  bool? channelChatCreated;
+  final bool? channelChatCreated;
 
   /// Optional. Service message: auto-delete timer settings changed in the chat
-  MessageAutoDeleteTimerChanged? messageAutoDeleteTimerChanged;
+  final MessageAutoDeleteTimerChanged? messageAutoDeleteTimerChanged;
 
   /// Optional. The group has been migrated to a supergroup with the specified identifier. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
-  int? migrateToChatId;
+  final int? migrateToChatId;
 
   /// Optional. The supergroup has been migrated from a group with the specified identifier. This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it. But it has at most 52 significant bits, so a signed 64-bit integer or double-precision float type are safe for storing this identifier.
-  int? migrateFromChatId;
+  final int? migrateFromChatId;
 
   /// Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
-  Message? pinnedMessage;
+  final Message? pinnedMessage;
 
   /// Optional. Message is an invoice for a payment, information about the invoice. [More about payments »](https://core.telegram.org/bots/api#payments)
-  Invoice? invoice;
+  final Invoice? invoice;
 
   /// Optional. Message is a service message about a successful payment, information about the payment. [More about payments »](https://core.telegram.org/bots/api#payments)
-  SuccessfulPayment? successfulPayment;
+  final SuccessfulPayment? successfulPayment;
 
   /// Optional. The domain name of the website on which the user has logged in. [More about Telegram Login »](https://core.telegram.org/widgets/login)
-  String? connectedWebsite;
+  final String? connectedWebsite;
 
   /// Optional. Telegram Passport data
-  PassportData? passportData;
+  final PassportData? passportData;
 
   /// Optional. Service message. A user in the chat triggered another user's proximity alert while sharing Live Location.
-  ProximityAlertTriggered? proximityAlertTriggered;
+  final ProximityAlertTriggered? proximityAlertTriggered;
 
   /// Optional. Service message: forum topic created
-  ForumTopicCreated? forumTopicCreated;
+  final ForumTopicCreated? forumTopicCreated;
 
   /// Optional. Service message: forum topic closed
-  ForumTopicClosed? forumTopicClosed;
+  final ForumTopicClosed? forumTopicClosed;
 
   /// Optional. Service message: forum topic reopened
-  ForumTopicReopened? forumTopicReopened;
+  final ForumTopicReopened? forumTopicReopened;
 
   /// Optional. Service message: video chat scheduled
-  VideoChatScheduled? videoChatScheduled;
+  final VideoChatScheduled? videoChatScheduled;
 
   /// Optional. Service message: video chat started
-  VideoChatStarted? videoChatStarted;
+  final VideoChatStarted? videoChatStarted;
 
   /// Optional. Service message: video chat ended
-  VideoChatEnded? videoChatEnded;
+  final VideoChatEnded? videoChatEnded;
 
   /// Optional. Service message: new participants invited to a video chat
-  VideoChatParticipantsInvited? videoChatParticipantsInvited;
+  final VideoChatParticipantsInvited? videoChatParticipantsInvited;
 
   /// Optional. Service message: data sent by a Web App
-  WebAppData? webAppData;
+  final WebAppData? webAppData;
 
   /// Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
-  InlineKeyboardMarkup? replyMarkup;
+  final InlineKeyboardMarkup? replyMarkup;
 
   /// Optional. Service message: a user was shared with the bot
-  UserShared? userShared;
+  final UserShared? userShared;
 
   /// Optional. Service message: a chat was shared with the bot
-  ChatShared? chatShared;
+  final ChatShared? chatShared;
 
   /// Optional. True, if the message media is covered by a spoiler animation
-  bool? hasMediaSpoiler;
+  final bool? hasMediaSpoiler;
 
   /// Optional. Service message: forum topic edited
-  ForumTopicEdited? forumTopicEdited;
+  final ForumTopicEdited? forumTopicEdited;
 
   /// Optional. Service message: the 'General' forum topic hidden
-  GeneralForumTopicHidden? generalForumTopicHidden;
+  final GeneralForumTopicHidden? generalForumTopicHidden;
 
   /// Optional. Service message: the 'General' forum topic unhidden
-  GeneralForumTopicUnhidden? generalForumTopicUnhidden;
+  final GeneralForumTopicUnhidden? generalForumTopicUnhidden;
 
   /// Optional. Service message: the user allowed the bot added to the attachment menu to write messages
-  WriteAccessAllowed? writeAccessAllowed;
+  final WriteAccessAllowed? writeAccessAllowed;
 
   /// Creates a Message object.
-  Message({
+  const Message({
     required this.messageId,
     this.from,
     this.senderChat,

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -547,4 +547,47 @@ class Message {
       ? entities!.first.type == MessageEntityType.botCommand &&
           entities!.first.offset == 0
       : false;
+
+  String? getEntityText(MessageEntityType type) {
+    if (entities == null || entities!.isEmpty) return null;
+    if ((text ?? caption) == null) return null;
+    if (entities?.any((element) => element.type == type) != true) return null;
+    final entity = (entities ?? captionEntities)
+        ?.firstWhere((element) => element.type == type);
+    if (entity == null) return null;
+    String entxt =
+        text!.substring(entity.offset, entity.offset + entity.length);
+
+    switch (type) {
+      case MessageEntityType.mention:
+      case MessageEntityType.hashtag:
+      case MessageEntityType.cashtag:
+        entxt = entxt.substring(1);
+        break;
+      case MessageEntityType.botCommand:
+        if (entxt.contains('@')) {
+          entxt = entxt.substring(0, entxt.indexOf('@'));
+        } else {
+          entxt = entxt.substring(1);
+        }
+        break;
+      case MessageEntityType.textMention:
+      case MessageEntityType.url:
+      case MessageEntityType.email:
+      case MessageEntityType.phoneNumber:
+      case MessageEntityType.bold:
+      case MessageEntityType.italic:
+      case MessageEntityType.underline:
+      case MessageEntityType.strikethrough:
+      case MessageEntityType.spoiler:
+      case MessageEntityType.code:
+      case MessageEntityType.pre:
+      case MessageEntityType.textLink:
+        break;
+      case MessageEntityType.customEmoji:
+        entxt = entity.customEmojiId!;
+        break;
+    }
+    return entxt;
+  }
 }

--- a/lib/src/telegram/models/update.dart
+++ b/lib/src/telegram/models/update.dart
@@ -5,50 +5,51 @@ part of models;
 /// At most one of the optional parameters can be present in any given update.
 class Update {
   /// The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
-  int updateId;
+  final int updateId;
 
   /// Optional. New incoming message of any kind — text, photo, sticker, etc.
-  Message? message;
+  final Message? message;
 
   /// Optional. New version of a message that is known to the bot and was edited
-  Message? editedMessage;
+  final Message? editedMessage;
 
   /// Optional. New incoming channel post of any kind - text, photo, sticker, etc.
-  Message? channelPost;
+  final Message? channelPost;
 
   /// Optional. New version of a channel post that is known to the bot and was edited
-  Message? editedChannelPost;
+  final Message? editedChannelPost;
 
   /// Optional. New incoming inline query
-  InlineQuery? inlineQuery;
+  final InlineQuery? inlineQuery;
 
   /// Optional. The result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.
-  ChosenInlineResult? chosenInlineResult;
+  final ChosenInlineResult? chosenInlineResult;
 
   /// Optional. New incoming callback query
-  CallbackQuery? callbackQuery;
+  final CallbackQuery? callbackQuery;
 
   /// Optional. New incoming shipping query. Only for invoices with flexible price
-  ShippingQuery? shippingQuery;
+  final ShippingQuery? shippingQuery;
 
   /// Optional. New incoming pre-checkout query. Contains full information about checkout
-  PreCheckoutQuery? preCheckoutQuery;
+  final PreCheckoutQuery? preCheckoutQuery;
 
   /// Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot
-  Poll? poll;
+  final Poll? poll;
 
   /// Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
-  PollAnswer? pollAnswer;
+  final PollAnswer? pollAnswer;
 
   /// Optional. New incoming my_chat_member update.
-  ChatMemberUpdated? myChatMember;
+  final ChatMemberUpdated? myChatMember;
 
   /// Optional. A chat member's status was updated in a chat. The bot must be an administrator in the chat and must explicitly specify “chat_member” in the list of allowed_updates to receive these updates.
-  ChatMemberUpdated? chatMember;
+  final ChatMemberUpdated? chatMember;
 
   /// Optional. A request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.
-  ChatJoinRequest? chatJoinRequest;
+  final ChatJoinRequest? chatJoinRequest;
 
+  /// Update Constructor
   Update({
     required this.updateId,
     this.message,
@@ -67,6 +68,7 @@ class Update {
     this.chatJoinRequest,
   });
 
+  /// Creates a [Update] from a json [Map].
   static Update fromJson(Map<String, dynamic> json) {
     return Update(
       updateId: json['update_id']!,
@@ -112,6 +114,7 @@ class Update {
     );
   }
 
+  /// Converts a [Update] to a [Map] which can be serialized to JSON.
   Map<String, dynamic> toJson() {
     return {
       'update_id': updateId,
@@ -132,8 +135,10 @@ class Update {
     }..removeWhere((key, value) => value == null);
   }
 
+  /// Converts a [Update] object to a JSON string.
   String toRawJson() => json.encode(toJson());
 
+  /// Returns the type of the update.
   UpdateType get type {
     if (message != null) {
       return UpdateType.message;

--- a/lib/src/televerse/event/event.dart
+++ b/lib/src/televerse/event/event.dart
@@ -10,8 +10,10 @@ part 'on.dart';
 ///
 /// You probably won't need to use this class directly, but you can use it to handle events.
 class Event {
+  /// If [sync] is true, events may be fired directly by the stream's subscriptions during an [StreamController.add], [StreamController.addError] or [StreamController.close] call. The returned stream controller is a [SynchronousStreamController], and must be used with the care and attention necessary to not break the [Stream] contract. See [Completer.sync] for some explanations on when a synchronous dispatching can be used. If in doubt, keep the controller non-sync.
+  ///
+  /// If [sync] is false, the event will always be fired at a later time, after the code adding the event has completed. In that case, no guarantees are given with regard to when multiple listeners get the events, except that each listener will get all events in the correct order. Each subscription handles the events individually. If two events are sent on an async controller with two listeners, one of the listeners may get both events before the other listener gets any. A listener must be subscribed both when the event is initiated (that is, when [add] is called) and when the event is later delivered, in order to receive the event.
   final bool sync;
-  Televerse? _televerse;
 
   /// Create a new Event instance.
   ///
@@ -21,209 +23,171 @@ class Event {
   ///
   /// If [sync] is false, the event will always be fired at a later time, after the code adding the event has completed. In that case, no guarantees are given with regard to when multiple listeners get the events, except that each listener will get all events in the correct order. Each subscription handles the events individually. If two events are sent on an async controller with two listeners, one of the listeners may get both events before the other listener gets any. A listener must be subscribed both when the event is initiated (that is, when [add] is called) and when the event is later delivered, in order to receive the event.
   Event({this.sync = false})
-      : _messageController = StreamController<MessageContext>.broadcast(
-          sync: sync,
-        ),
-        _editedMessageController = StreamController<MessageContext>.broadcast(
-          sync: sync,
-        ),
-        _channelPostController = StreamController<MessageContext>.broadcast(
-          sync: sync,
-        ),
-        _editedChannelPostController =
-            StreamController<MessageContext>.broadcast(
-          sync: sync,
-        ),
-        _inlineQueryController = StreamController<InlineQueryContext>.broadcast(
-          sync: sync,
-        ),
-        _chosenInlineResultController =
-            StreamController<ChosenInlineResult>.broadcast(
-          sync: sync,
-        ),
-        _callbackQueryController =
-            StreamController<CallbackQueryContext>.broadcast(
-          sync: sync,
-        ),
-        _shippingQueryController = StreamController<ShippingQuery>.broadcast(
-          sync: sync,
-        ),
-        _preCheckoutQueryController =
-            StreamController<PreCheckoutQuery>.broadcast(
-          sync: sync,
-        ),
-        _pollController = StreamController<Poll>.broadcast(
-          sync: sync,
-        ),
-        _pollAnswerController = StreamController<PollAnswer>.broadcast(
-          sync: sync,
-        ),
-        _myChatMemberController = StreamController<ChatMemberUpdated>.broadcast(
-          sync: sync,
-        ),
-        _chatMemberController = StreamController<ChatMemberUpdated>.broadcast(
-          sync: sync,
-        ),
-        _chatJoinRequestController =
-            StreamController<ChatJoinRequest>.broadcast(
-          sync: sync,
-        ),
-        _updateStreamController = StreamController<Update>.broadcast(
+      : _updateStreamController = StreamController<Update>.broadcast(
           sync: sync,
         );
-
-  /// Stream Controller to handle incoming messages.
-  final StreamController<MessageContext> _messageController;
-
-  /// Stream Controller to handle edited messages.
-  final StreamController<MessageContext> _editedMessageController;
-
-  /// Stream Controller to handle channel posts.
-  final StreamController<MessageContext> _channelPostController;
-
-  /// Stream Controller to handle edited channel posts.
-  final StreamController<MessageContext> _editedChannelPostController;
-
-  /// Stream Controller to handle inline queries.
-  final StreamController<InlineQueryContext> _inlineQueryController;
-
-  /// Stream Controller to handle chosen inline results.
-  final StreamController<ChosenInlineResult> _chosenInlineResultController;
-
-  /// Stream Controller to handle callback queries.
-  final StreamController<CallbackQueryContext> _callbackQueryController;
-
-  /// Stream Controller to handle shipping queries.
-  final StreamController<ShippingQuery> _shippingQueryController;
-
-  /// Stream Controller to handle pre-checkout queries.
-  final StreamController<PreCheckoutQuery> _preCheckoutQueryController;
-
-  /// Stream Controller to handle polls.
-  final StreamController<Poll> _pollController;
-
-  /// Stream Controller to handle poll answers.
-  final StreamController<PollAnswer> _pollAnswerController;
-
-  /// Stream Controller to handle my chat member updates.
-  final StreamController<ChatMemberUpdated> _myChatMemberController;
-
-  /// Stream Controller to handle chat member updates.
-  final StreamController<ChatMemberUpdated> _chatMemberController;
-
-  /// Stream Controller to handle chat join requests.
-  final StreamController<ChatJoinRequest> _chatJoinRequestController;
 
   /// Stream Controller to handle updates.
   final StreamController<Update> _updateStreamController;
 
   /// **onMessage** is a stream of [MessageContext] which is emitted when a message of any type is is received.
-  Stream<MessageContext> get onMessage => _messageController.stream;
+  Stream<MessageContext> get onMessage =>
+      onUpdate(UpdateType.message).map(mapper<MessageContext>);
 
   /// **onEditedMessage** is a stream of [MessageContext] which is emitted when a message is edited.
-  Stream<MessageContext> get onEditedMessage => _editedMessageController.stream;
+  Stream<MessageContext> get onEditedMessage =>
+      onUpdate(UpdateType.editedMessage).map(mapper<MessageContext>);
 
   /// **onChannelPost** is a stream of [MessageContext] which is emitted when a message is sent to a channel.
-  Stream<MessageContext> get onChannelPost => _channelPostController.stream;
+  Stream<MessageContext> get onChannelPost =>
+      onUpdate(UpdateType.channelPost).map(mapper<MessageContext>);
 
   /// **onEditedChannelPost** is a stream of [MessageContext] which is emitted when a message is edited in a channel.
   Stream<MessageContext> get onEditedChannelPost =>
-      _editedChannelPostController.stream;
+      onUpdate(UpdateType.editedChannelPost).map(mapper<MessageContext>);
 
   /// **onInlineQuery** is a stream of [InlineQueryContext] which is emitted when an inline query is received.
-  Stream<InlineQueryContext> get onInlineQuery => _inlineQueryController.stream;
+  Stream<InlineQueryContext> get onInlineQuery =>
+      onUpdate(UpdateType.inlineQuery).map(mapper<InlineQueryContext>);
 
   /// **onChosenInlineResult** is a stream of [ChosenInlineResult] which is emitted when a user chooses an inline result.
-  Stream<ChosenInlineResult> get onChosenInlineResult =>
-      _chosenInlineResultController.stream;
+  Stream<ChosenInlineResult> get onChosenInlineResult => onUpdate(
+        UpdateType.chosenInlineResult,
+      ).map(mapper<ChosenInlineResult>);
 
   /// **onCallbackQuery** is a stream of [CallbackQueryContext] which is emitted when a callback query is received.
-  Stream<CallbackQueryContext> get onCallbackQuery =>
-      _callbackQueryController.stream;
+  Stream<CallbackQueryContext> get onCallbackQuery => onUpdate(
+        UpdateType.callbackQuery,
+      ).map(mapper<CallbackQueryContext>);
 
   /// **onShippingQuery** is a stream of [ShippingQuery] which is emitted when a shipping query is received.
-  Stream<ShippingQuery> get onShippingQuery => _shippingQueryController.stream;
+  Stream<ShippingQuery> get onShippingQuery => onUpdate(
+        UpdateType.shippingQuery,
+      ).map(mapper<ShippingQuery>);
 
   /// **onPreCheckoutQuery** is a stream of [PreCheckoutQuery] which is emitted when a pre-checkout query is received.
   Stream<PreCheckoutQuery> get onPreCheckoutQuery =>
-      _preCheckoutQueryController.stream;
+      onUpdate(UpdateType.preCheckoutQuery).map(mapper<PreCheckoutQuery>);
 
   /// **onPoll** is a stream of [Poll] which is emitted when a poll is received.
-  Stream<Poll> get onPoll => _pollController.stream;
+  Stream<Poll> get onPoll => onUpdate(UpdateType.poll).map(mapper<Poll>);
 
   /// **onPollAnswer** is a stream of [PollAnswer] which is emitted when a poll answer is received.
-  Stream<PollAnswer> get onPollAnswer => _pollAnswerController.stream;
+  Stream<PollAnswer> get onPollAnswer => onUpdate(
+        UpdateType.pollAnswer,
+      ).map(mapper<PollAnswer>);
 
   /// **onMyChatMember** is a stream of [ChatMemberUpdated] which is emitted when the bot's chat member status is updated.
   Stream<ChatMemberUpdated> get onMyChatMember =>
-      _myChatMemberController.stream;
+      onUpdate(UpdateType.myChatMember).map(mapper<ChatMemberUpdated>);
 
   /// **onChatMember** is a stream of [ChatMemberUpdated] which is emitted when a chat member's status is updated.
-  Stream<ChatMemberUpdated> get onChatMember => _chatMemberController.stream;
+  Stream<ChatMemberUpdated> get onChatMember => onUpdate(
+        UpdateType.chatMember,
+      ).map(mapper<ChatMemberUpdated>);
 
   /// **onChatJoinRequest** is a stream of [ChatJoinRequest] which is emitted when a user requests to join a chat.
   Stream<ChatJoinRequest> get onChatJoinRequest =>
-      _chatJoinRequestController.stream;
+      onUpdate(UpdateType.chatJoinRequest)
+          .map<ChatJoinRequest>(mapper<ChatJoinRequest>);
 
   /// **onUpdate** is a stream of [Update] which is emitted when any update is received.
-  Stream<Update> get onUpdate => _updateStreamController.stream;
+  Stream<Update> onUpdate([UpdateType? type]) {
+    if (type == null) {
+      return _updateStreamController.stream;
+    } else {
+      return _updateStreamController.stream.where(
+        (update) => update.type == type,
+      );
+    }
+  }
+
+  T mapper<T>(Update update) {
+    if (T == MessageContext && update.type == UpdateType.message) {
+      return MessageContext(
+        Televerse.instance.api,
+        update.message!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == MessageContext && update.type == UpdateType.editedMessage) {
+      return MessageContext(
+        Televerse.instance.api,
+        update.editedMessage!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == MessageContext && update.type == UpdateType.channelPost) {
+      return MessageContext(
+        Televerse.instance.api,
+        update.channelPost!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == MessageContext && update.type == UpdateType.editedChannelPost) {
+      return MessageContext(
+        Televerse.instance.api,
+        update.editedChannelPost!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == InlineQueryContext) {
+      return InlineQueryContext(
+        Televerse.instance.api,
+        update.inlineQuery!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == CallbackQueryContext) {
+      return CallbackQueryContext(
+        Televerse.instance.api,
+        update.callbackQuery!,
+        update: update,
+      ) as T;
+    }
+
+    if (T == ChosenInlineResult) {
+      return update.chosenInlineResult! as T;
+    }
+
+    if (T == ShippingQuery) {
+      return update.shippingQuery! as T;
+    }
+
+    if (T == PreCheckoutQuery) {
+      return update.preCheckoutQuery! as T;
+    }
+
+    if (T == Poll) {
+      return update.poll! as T;
+    }
+
+    if (T == PollAnswer) {
+      return update.pollAnswer! as T;
+    }
+
+    if (T == ChatMemberUpdated && update.type == UpdateType.myChatMember) {
+      return update.myChatMember! as T;
+    }
+
+    if (T == ChatMemberUpdated && update.type == UpdateType.chatMember) {
+      return update.chatMember! as T;
+    }
+
+    if (T == ChatJoinRequest) {
+      return update.chatJoinRequest! as T;
+    }
+
+    return update as T;
+  }
 
   /// Use this method to emit an update to the streams.
   void emitUpdate(Update update, Televerse televerse) {
-    _televerse ??= televerse;
     _updateStreamController.add(update);
-    if (update.type == UpdateType.message) {
-      _messageController.add(MessageContext(
-        televerse.api,
-        update.message!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.editedMessage) {
-      _editedMessageController.add(MessageContext(
-        televerse.api,
-        update.editedMessage!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.channelPost) {
-      _channelPostController.add(MessageContext(
-        televerse.api,
-        update.channelPost!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.editedChannelPost) {
-      _editedChannelPostController.add(MessageContext(
-        televerse.api,
-        update.editedChannelPost!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.inlineQuery) {
-      _inlineQueryController.add(InlineQueryContext(
-        televerse.api,
-        update.inlineQuery!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.chosenInlineResult) {
-      _chosenInlineResultController.add(update.chosenInlineResult!);
-    } else if (update.type == UpdateType.callbackQuery) {
-      _callbackQueryController.add(CallbackQueryContext(
-        televerse.api,
-        update.callbackQuery!,
-        update: update,
-      ));
-    } else if (update.type == UpdateType.shippingQuery) {
-      _shippingQueryController.add(update.shippingQuery!);
-    } else if (update.type == UpdateType.preCheckoutQuery) {
-      _preCheckoutQueryController.add(update.preCheckoutQuery!);
-    } else if (update.type == UpdateType.poll) {
-      _pollController.add(update.poll!);
-    } else if (update.type == UpdateType.pollAnswer) {
-      _pollAnswerController.add(update.pollAnswer!);
-    } else if (update.type == UpdateType.myChatMember) {
-      _myChatMemberController.add(update.myChatMember!);
-    } else if (update.type == UpdateType.chatMember) {
-      _chatMemberController.add(update.chatMember!);
-    } else if (update.type == UpdateType.chatJoinRequest) {
-      _chatJoinRequestController.add(update.chatJoinRequest!);
-    }
   }
 }

--- a/lib/src/televerse/event/event.dart
+++ b/lib/src/televerse/event/event.dart
@@ -32,64 +32,64 @@ class Event {
 
   /// **onMessage** is a stream of [MessageContext] which is emitted when a message of any type is is received.
   Stream<MessageContext> get onMessage =>
-      onUpdate(UpdateType.message).map(mapper<MessageContext>);
+      onUpdate(UpdateType.message).map(_mapper<MessageContext>);
 
   /// **onEditedMessage** is a stream of [MessageContext] which is emitted when a message is edited.
   Stream<MessageContext> get onEditedMessage =>
-      onUpdate(UpdateType.editedMessage).map(mapper<MessageContext>);
+      onUpdate(UpdateType.editedMessage).map(_mapper<MessageContext>);
 
   /// **onChannelPost** is a stream of [MessageContext] which is emitted when a message is sent to a channel.
   Stream<MessageContext> get onChannelPost =>
-      onUpdate(UpdateType.channelPost).map(mapper<MessageContext>);
+      onUpdate(UpdateType.channelPost).map(_mapper<MessageContext>);
 
   /// **onEditedChannelPost** is a stream of [MessageContext] which is emitted when a message is edited in a channel.
   Stream<MessageContext> get onEditedChannelPost =>
-      onUpdate(UpdateType.editedChannelPost).map(mapper<MessageContext>);
+      onUpdate(UpdateType.editedChannelPost).map(_mapper<MessageContext>);
 
   /// **onInlineQuery** is a stream of [InlineQueryContext] which is emitted when an inline query is received.
   Stream<InlineQueryContext> get onInlineQuery =>
-      onUpdate(UpdateType.inlineQuery).map(mapper<InlineQueryContext>);
+      onUpdate(UpdateType.inlineQuery).map(_mapper<InlineQueryContext>);
 
   /// **onChosenInlineResult** is a stream of [ChosenInlineResult] which is emitted when a user chooses an inline result.
   Stream<ChosenInlineResult> get onChosenInlineResult => onUpdate(
         UpdateType.chosenInlineResult,
-      ).map(mapper<ChosenInlineResult>);
+      ).map(_mapper<ChosenInlineResult>);
 
   /// **onCallbackQuery** is a stream of [CallbackQueryContext] which is emitted when a callback query is received.
   Stream<CallbackQueryContext> get onCallbackQuery => onUpdate(
         UpdateType.callbackQuery,
-      ).map(mapper<CallbackQueryContext>);
+      ).map(_mapper<CallbackQueryContext>);
 
   /// **onShippingQuery** is a stream of [ShippingQuery] which is emitted when a shipping query is received.
   Stream<ShippingQuery> get onShippingQuery => onUpdate(
         UpdateType.shippingQuery,
-      ).map(mapper<ShippingQuery>);
+      ).map(_mapper<ShippingQuery>);
 
   /// **onPreCheckoutQuery** is a stream of [PreCheckoutQuery] which is emitted when a pre-checkout query is received.
   Stream<PreCheckoutQuery> get onPreCheckoutQuery =>
-      onUpdate(UpdateType.preCheckoutQuery).map(mapper<PreCheckoutQuery>);
+      onUpdate(UpdateType.preCheckoutQuery).map(_mapper<PreCheckoutQuery>);
 
   /// **onPoll** is a stream of [Poll] which is emitted when a poll is received.
-  Stream<Poll> get onPoll => onUpdate(UpdateType.poll).map(mapper<Poll>);
+  Stream<Poll> get onPoll => onUpdate(UpdateType.poll).map(_mapper<Poll>);
 
   /// **onPollAnswer** is a stream of [PollAnswer] which is emitted when a poll answer is received.
   Stream<PollAnswer> get onPollAnswer => onUpdate(
         UpdateType.pollAnswer,
-      ).map(mapper<PollAnswer>);
+      ).map(_mapper<PollAnswer>);
 
   /// **onMyChatMember** is a stream of [ChatMemberUpdated] which is emitted when the bot's chat member status is updated.
   Stream<ChatMemberUpdated> get onMyChatMember =>
-      onUpdate(UpdateType.myChatMember).map(mapper<ChatMemberUpdated>);
+      onUpdate(UpdateType.myChatMember).map(_mapper<ChatMemberUpdated>);
 
   /// **onChatMember** is a stream of [ChatMemberUpdated] which is emitted when a chat member's status is updated.
   Stream<ChatMemberUpdated> get onChatMember => onUpdate(
         UpdateType.chatMember,
-      ).map(mapper<ChatMemberUpdated>);
+      ).map(_mapper<ChatMemberUpdated>);
 
   /// **onChatJoinRequest** is a stream of [ChatJoinRequest] which is emitted when a user requests to join a chat.
   Stream<ChatJoinRequest> get onChatJoinRequest =>
       onUpdate(UpdateType.chatJoinRequest)
-          .map<ChatJoinRequest>(mapper<ChatJoinRequest>);
+          .map<ChatJoinRequest>(_mapper<ChatJoinRequest>);
 
   /// **onUpdate** is a stream of [Update] which is emitted when any update is received.
   Stream<Update> onUpdate([UpdateType? type]) {
@@ -102,7 +102,7 @@ class Event {
     }
   }
 
-  T mapper<T>(Update update) {
+  T _mapper<T>(Update update) {
     if (T == MessageContext && update.type == UpdateType.message) {
       return MessageContext(
         Televerse.instance.api,

--- a/lib/src/televerse/event/on.dart
+++ b/lib/src/televerse/event/on.dart
@@ -9,10 +9,8 @@ mixin OnEvent on Event {
   /// The call back will be only be executed on specific update types. You can
   /// use the [TeleverseEvent] object to specify which update you want to listen to.
   void on(TeleverseEvent type, void Function(Context ctx) callback) {
-    onUpdate.listen((update) {
-      if (_televerse == null) return;
-      RawAPI api = _televerse!.api;
-
+    RawAPI api = Televerse.instance.api;
+    onUpdate().listen((update) {
       bool isMessage = update.message != null;
       bool isChannelPost = update.channelPost != null;
       bool isEditedMessage = update.editedMessage != null;
@@ -39,10 +37,7 @@ mixin OnEvent on Event {
           ) ??
           false;
 
-      bool isTextMessage = message?.text != null &&
-          (message?.entities?.every(
-                  (entity) => entity.type != MessageEntityType.botCommand) ??
-              false);
+      bool isTextMessage = message?.text != null && !isCommand;
       bool isAudio = message?.audio != null;
       bool isAudioMessage =
           update.message?.audio != null || update.editedMessage?.audio != null;

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -1221,7 +1221,6 @@ class RawAPI {
     bool response = await HttpClient.getURI(
       _buildUri("banChatMember", params),
     );
-    print(response);
     return response;
   }
 

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -336,4 +336,58 @@ class Televerse extends Event with OnEvent {
   ) {
     _onError = handler;
   }
+
+  /// Registers a callback for messages that contains the specified entity type.
+  ///
+  /// Pass the `shouldMatchCaptionEntities` parameter to match entities in the
+  /// caption of a message. Such as a photo or video message.
+  ///
+  /// By default, this method will ONLY match entities in the message text.
+  void entity(
+    MessageEntityType type,
+    MessageHandler callback, {
+    bool shouldMatchCaptionEntities = false,
+  }) {
+    onMessage.listen((MessageContext context) {
+      List<MessageEntity>? entities = context.message.entities;
+      if (shouldMatchCaptionEntities) {
+        entities = entities ?? context.message.captionEntities;
+      }
+      if (entities == null) return;
+      bool hasMatch = entities.any((element) => element.type == type);
+      if (hasMatch) {
+        callback(context);
+      }
+    });
+  }
+
+  /// Registers a callback for messages that contains the specified entity types.
+  /// The callback will be called when a message is received that contains the
+  /// specified entity types.
+  ///
+  /// Pass the `shouldMatchCaptionEntities` parameter to match entities in the
+  /// caption of a message. Such as a photo or video message.
+  ///
+  /// By default, this method will ONLY match entities in the message text.
+  void entities(
+    List<MessageEntityType> types,
+    MessageHandler callback, {
+    bool shouldMatchCaptionEntities = false,
+  }) {
+    onMessage.listen((MessageContext context) {
+      List<MessageEntity>? entities = context.message.entities;
+      if (shouldMatchCaptionEntities) {
+        entities = entities ?? context.message.captionEntities;
+      }
+      if (entities == null) return;
+
+      bool hasMatch = types.every((element) => entities!.any(
+            (e) => e.type == element,
+          ));
+
+      if (hasMatch) {
+        callback(context);
+      }
+    });
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.5!
-version: 1.4.6
+version: 1.4.7
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
## Changes: 

- Added `Televerse.entity` method to listen to entities in messages.
- Improved code quality.
- Removed all the different StreamController classes and replaced them with a single `StreamController<Update>` instance.
- All the event streams are now based on the `onUpdate` stream.
- Added `Message.getEntityText` method to get the text of the entity.
- Updated the [televerse_example](./example/televerse_example.dart) file to reflect the changes.