### PR TITLE
The `copyMessage` fix and `command` improvement 🤖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.6
+- Fixed an issue with `RawAPI.copyMessage` method.
+- Updated the `Televerse.command` method to accept a `String` or `RegExp` as the `command` parameter.
+
 ## 1.5.5 
 - Changed the `data` parameter to accept both `String` and `RegExp` using `Pattern` type on `Televerse.callbackQuery` method.
 - This can simplify the code when you want to listen to a callback query with a specific data.

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -282,7 +282,7 @@ class RawAPI {
       "protect_content": protectContent,
       "reply_to_message_id": replyToMessageId,
       "allow_sending_without_reply": allowSendingWithoutReply,
-      "reply_markup": jsonEncode(jsonEncode(replyMarkup?.toJson())),
+      "reply_markup": jsonEncode(replyMarkup?.toJson()),
     };
     Uri uri = _buildUri("copyMessage", params);
 

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -93,9 +93,7 @@ class Televerse extends Event with OnEvent {
         throw err;
       }
     });
-    fetcher.onUpdate().listen((update) {
-      _onUpdate(update);
-    });
+    fetcher.onUpdate().listen(_onUpdate);
 
     // Registers a handler to listen for /start command
     if (handler != null) {

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -127,23 +127,24 @@ class Televerse extends Event with OnEvent {
   /// This will reply "Hello!" to any message that starts with `/start`.
   ///
   /// Optionally, you can specify a [pattern] to match the command with. If the command matches the pattern, the [MessageContext.matches] will be set to the matches.
-  void command(
-    String command,
-    MessageHandler callback, {
-    RegExp? pattern,
-  }) {
+  void command(Pattern command, MessageHandler callback) {
     onMessage.listen((MessageContext context) {
       if (context.message.text == null) return;
-      if (context.message.text!.startsWith('/$command')) {
-        if (command == 'start' && context.message.text!.split(' ').length > 1) {
-          context.startParameter =
-              context.message.text!.split(' ').sublist(1).join(' ');
+      if (command is RegExp) {
+        if (command.hasMatch(context.message.text!)) {
+          context.matches = command.allMatches(context.message.text!).toList();
+          callback(context);
         }
-        if (pattern != null) {
-          context.matches = pattern.allMatches(context.message.text!).toList();
-        }
+      } else if (command is String) {
+        if (context.message.text!.startsWith('/$command')) {
+          if (command == 'start' &&
+              context.message.text!.split(' ').length > 1) {
+            context.startParameter =
+                context.message.text!.split(' ').sublist(1).join(' ');
+          }
 
-        callback(context);
+          callback(context);
+        }
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.6!
-version: 1.5.5
+version: 1.5.6
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
There existed an issue with the `RawAPI.copyMessage` which caused it to forever fail. Fixed it.

The `Televerse.command` method can now accept both `String` and `RegExp` as the `command` parameter using the `Pattern` type. This helps in improved accessibility.