### PR TITLE
Bot API 6.7 🤖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.0
+- 🤖 Bot API 6.7 is added! 
+- [Read more here](https://github.com/HeySreelal/televerse/issues/65).
+- [BREAKING] 👨🏻‍🔧 - The `answerInlineQuery` will no longer accept `switchPmParameter` or `switchPmText` parameters.
+- The example files are updated with dartdoc comments.
 ## 1.6.0
 - ⚗️ **BREAKING** - The `allowedUpdates` parameter in the `LongPolling` object now accepts the list of `UpdateType` instead of `String`
 - Added methods `requestChat` and `requestUser` in `Keyboard`

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Televerse is simple & efficient way to create Telegram bots with Dart.
 
-![](https://shields.io/badge/Latest-Bot%20API%206.6-blue)
+![](https://shields.io/badge/Latest-Bot%20API%206.7-blue)
 
-🤖 `Bot API version: Bot API 6.6 (March 9, 2023)`
+🤖 `Bot API version: Bot API 6.7 (April 21, 2023)`
 
 ## 👨🏻‍💻 Installation
 

--- a/lib/src/telegram/models/bot_name.dart
+++ b/lib/src/telegram/models/bot_name.dart
@@ -1,0 +1,26 @@
+part of models;
+
+/// This object represents the bot's name.
+class BotName {
+  /// The bot's name
+  final String name;
+
+  /// Creates a new BotName object
+  const BotName({
+    required this.name,
+  });
+
+  /// Constructs [BotName] from JSON
+  factory BotName.fromJson(Map<String, dynamic> json) {
+    return BotName(
+      name: json['name'],
+    );
+  }
+
+  /// Converts [BotName] to JSON
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+    }..removeWhere((_, value) => value == null);
+  }
+}

--- a/lib/src/telegram/models/chat_member_updated.dart
+++ b/lib/src/telegram/models/chat_member_updated.dart
@@ -22,6 +22,11 @@ class ChatMemberUpdated {
   /// Optional. Chat invite link, which was used by the user to join the chat; for joining by invite link events only.
   final ChatInviteLink? inviteLink;
 
+  /// Optional. True, if the user joined the chat via a chat folder invite link
+  ///
+  /// Since Bot API 6.7
+  final bool? viaChatFolderInviteLink;
+
   /// Creates a new [ChatMemberUpdated] object.
   const ChatMemberUpdated({
     required this.chat,
@@ -30,6 +35,7 @@ class ChatMemberUpdated {
     required this.oldChatMember,
     required this.newChatMember,
     this.inviteLink,
+    this.viaChatFolderInviteLink,
   });
 
   /// Creates a new [ChatMemberUpdated] object from json.
@@ -46,6 +52,7 @@ class ChatMemberUpdated {
           ? null
           : ChatInviteLink.fromJson(
               json['invite_link'] as Map<String, dynamic>),
+      viaChatFolderInviteLink: json['via_chat_folder_invite_link'] as bool?,
     );
   }
 
@@ -58,6 +65,7 @@ class ChatMemberUpdated {
       'old_chat_member': oldChatMember.toJson(),
       'new_chat_member': newChatMember.toJson(),
       'invite_link': inviteLink?.toJson(),
+      'via_chat_folder_invite_link': viaChatFolderInviteLink,
     }..removeWhere((key, value) => value == null);
   }
 

--- a/lib/src/telegram/models/inline_keyboard_button.dart
+++ b/lib/src/telegram/models/inline_keyboard_button.dart
@@ -37,6 +37,11 @@ class InlineKeyboardButton {
   /// Optional. Description of the Web App that will be launched when the user presses the button. The Web App will be able to send an arbitrary message on behalf of the user using the method answerWebAppQuery. Available only in private chats between a user and the bot.
   WebAppInfo? webAppInfo;
 
+  /// Optional. If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field
+  ///
+  /// Since Bot API 6.7
+  SwitchInlineQueryChosenChat? switchInlineQueryChosenChat;
+
   /// This object represents one button of an inline keyboard.
   ///
   /// The inline keyboard consists of a row of buttons, each represented by an [InlineKeyboardButton] object. You can use the various fields to specify the behavior of the button.
@@ -50,6 +55,7 @@ class InlineKeyboardButton {
     this.callbackGame,
     this.pay,
     this.webAppInfo,
+    this.switchInlineQueryChosenChat,
   });
 
   /// Creates an [InlineKeyboardButton] from JSON object
@@ -70,6 +76,11 @@ class InlineKeyboardButton {
       webAppInfo: json['web_app_info'] != null
           ? WebAppInfo.fromJson(json['web_app_info'])
           : null,
+      switchInlineQueryChosenChat:
+          json['switch_inline_query_chosen_chat'] != null
+              ? SwitchInlineQueryChosenChat.fromJson(
+                  json['switch_inline_query_chosen_chat'])
+              : null,
     );
   }
 
@@ -85,6 +96,7 @@ class InlineKeyboardButton {
       'callback_game': callbackGame?.toJson(),
       'pay': pay,
       'web_app_info': webAppInfo?.toJson(),
+      'switch_inline_query_chosen_chat': switchInlineQueryChosenChat?.toJson(),
     }..removeWhere((key, value) => value == null);
   }
 }

--- a/lib/src/telegram/models/inline_query_results_button.dart
+++ b/lib/src/telegram/models/inline_query_results_button.dart
@@ -1,0 +1,43 @@
+part of models;
+
+/// This object represents a button to be shown above inline query results. You must use exactly one of the optional fields.
+///
+/// Since: Bot API 6.7
+class InlineQueryResultsButton {
+  /// Label text on the button
+  final String text;
+
+  /// Optional. Description of the Web App that will be launched when the user presses the button. The Web App will be able to switch back to the inline mode using the method web_app_switch_inline_query inside the Web App.
+  final WebAppInfo? webApp;
+
+  /// Optional. Deep-linking parameter for the /start message sent to the bot when a user presses the button. 1-64 characters, only `A-Z`, `a-z`, `0-9`, `_` and `-` are allowed.
+  ///
+  /// Example: An inline bot that sends YouTube videos can ask the user to connect the bot to their YouTube account to adapt search results accordingly. To do this, it displays a 'Connect your YouTube account' button above the results, or even before showing any. The user presses the button, switches to a private chat with the bot and, in doing so, passes a start parameter that instructs the bot to return an OAuth link. Once done, the bot can offer a switch_inline button so that the user can easily return to the chat where they wanted to use the bot's inline capabilities.
+  final String? startParameter;
+
+  /// Constructs an [InlineQueryResultsButton]
+  InlineQueryResultsButton({
+    required this.text,
+    this.webApp,
+    this.startParameter,
+  });
+
+  /// Converts this object to a map in JSON format.
+  Map<String, dynamic> toJson() {
+    return {
+      'text': text,
+      'web_app': webApp?.toJson(),
+      'start_parameter': startParameter,
+    }..removeWhere((_, v) => v == null);
+  }
+
+  /// Creates an [InlineQueryResultsButton] from a JSON object.
+  factory InlineQueryResultsButton.fromJson(Map<String, dynamic> json) {
+    return InlineQueryResultsButton(
+      text: json['text'],
+      webApp:
+          json['web_app'] != null ? WebAppInfo.fromJson(json['web_app']) : null,
+      startParameter: json['start_parameter'],
+    );
+  }
+}

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -149,3 +149,4 @@ part 'input_sticker.dart';
 
 // Bot API 6.7
 part 'inline_query_results_button.dart';
+part 'switch_inline_query_chosen_chat.dart';

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -146,3 +146,6 @@ part 'chat_shared.dart';
 part 'bot_description.dart';
 part 'bot_short_description.dart';
 part 'input_sticker.dart';
+
+// Bot API 6.7
+part 'inline_query_results_button.dart';

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -150,3 +150,4 @@ part 'input_sticker.dart';
 // Bot API 6.7
 part 'inline_query_results_button.dart';
 part 'switch_inline_query_chosen_chat.dart';
+part 'bot_name.dart';

--- a/lib/src/telegram/models/switch_inline_query_chosen_chat.dart
+++ b/lib/src/telegram/models/switch_inline_query_chosen_chat.dart
@@ -1,0 +1,49 @@
+part of models;
+
+/// This object represents an inline button that switches the current user to inline mode in a chosen chat, with an optional default inline query.
+class SwitchInlineQueryChosenChat {
+  /// Optional. The default inline query to be inserted in the input field. If left empty, only the bot's username will be inserted
+  final String? query;
+
+  /// Optional. True, if private chats with users can be chosen
+  final bool? allowUserChats;
+
+  /// Optional. True, if private chats with bots can be chosen
+  final bool? allowBotChats;
+
+  /// Optional. True, if group and supergroup chats can be chosen
+  final bool? allowGroupChats;
+
+  /// Optional. True, if channel chats can be chosen
+  final bool? allowChannelChats;
+
+  const SwitchInlineQueryChosenChat({
+    this.query,
+    this.allowUserChats,
+    this.allowBotChats,
+    this.allowGroupChats,
+    this.allowChannelChats,
+  });
+
+  /// Creates a [SwitchInlineQueryChosenChat] object from JSON object
+  factory SwitchInlineQueryChosenChat.fromJson(Map<String, dynamic> json) {
+    return SwitchInlineQueryChosenChat(
+      query: json['query'],
+      allowUserChats: json['allow_user_chats'],
+      allowBotChats: json['allow_bot_chats'],
+      allowGroupChats: json['allow_group_chats'],
+      allowChannelChats: json['allow_channel_chats'],
+    );
+  }
+
+  /// Converts a [SwitchInlineQueryChosenChat] object to JSON object
+  Map<String, dynamic> toJson() {
+    return {
+      'query': query,
+      'allow_user_chats': allowUserChats,
+      'allow_bot_chats': allowBotChats,
+      'allow_group_chats': allowGroupChats,
+      'allow_channel_chats': allowChannelChats,
+    }..removeWhere((_, value) => value == null);
+  }
+}

--- a/lib/src/telegram/models/switch_inline_query_chosen_chat.dart
+++ b/lib/src/telegram/models/switch_inline_query_chosen_chat.dart
@@ -17,6 +17,7 @@ class SwitchInlineQueryChosenChat {
   /// Optional. True, if channel chats can be chosen
   final bool? allowChannelChats;
 
+  /// Constructs a [SwitchInlineQueryChosenChat]
   const SwitchInlineQueryChosenChat({
     this.query,
     this.allowUserChats,

--- a/lib/src/telegram/models/write_access_allowed.dart
+++ b/lib/src/telegram/models/write_access_allowed.dart
@@ -1,17 +1,25 @@
 part of models;
 
-/// This object represents a service message about a user allowing a bot added to the attachment menu to write messages. Currently holds no information.
+/// This object represents a service message about a user allowing a bot added to the attachment menu to write messages.
 class WriteAccessAllowed {
+  final String? webAppName;
+
   /// Constructs a [WriteAccessAllowed] object
-  WriteAccessAllowed();
+  const WriteAccessAllowed({
+    this.webAppName,
+  });
 
   /// Converts a [WriteAccessAllowed] object to JSON object
   Map<String, dynamic> toJson() {
-    return {};
+    return {
+      'web_app_name': webAppName,
+    }..removeWhere((key, value) => value == null);
   }
 
   /// Creates a [WriteAccessAllowed] object from JSON object
   factory WriteAccessAllowed.fromJson(Map<String, dynamic> json) {
-    return WriteAccessAllowed();
+    return WriteAccessAllowed(
+      webAppName: json['web_app_name'],
+    );
   }
 }

--- a/lib/src/televerse/context/mixins/inline_mixin.dart
+++ b/lib/src/televerse/context/mixins/inline_mixin.dart
@@ -14,6 +14,7 @@ mixin InlineQueryMixin on Context {
     String? nextOffset,
     String? switchPmText,
     String? switchPmParameter,
+    InlineQueryResultsButton? button,
   }) async {
     await api.answerInlineQuery(
       inlineQuery.id,
@@ -21,8 +22,7 @@ mixin InlineQueryMixin on Context {
       cacheTime: cacheTime,
       isPersonal: isPersonal,
       nextOffset: nextOffset,
-      switchPmText: switchPmText,
-      switchPmParameter: switchPmParameter,
+      button: button,
     );
   }
 
@@ -32,8 +32,7 @@ mixin InlineQueryMixin on Context {
     int? cacheTime,
     bool? isPersonal,
     String? nextOffset,
-    String? switchPmText,
-    String? switchPmParameter,
+    InlineQueryResultsButton? button,
   }) async {
     await api.answerInlineQuery(
       inlineQuery.id,
@@ -41,8 +40,7 @@ mixin InlineQueryMixin on Context {
       cacheTime: cacheTime,
       isPersonal: isPersonal,
       nextOffset: nextOffset,
-      switchPmText: switchPmText,
-      switchPmParameter: switchPmParameter,
+      button: button,
     );
   }
 }

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -2746,14 +2746,15 @@ class RawAPI {
 
   /// Use this method to send answers to an inline query. On success, True is returned.
   /// No more than 50 results per query are allowed.
+  ///
+  /// [button] - A JSON-serialized object describing a button to be shown above inline query results
   Future<bool> answerInlineQuery(
     String inlineQueryId,
     List<InlineQueryResult> results, {
     int? cacheTime = 300,
     bool? isPersonal,
     String? nextOffset,
-    String? switchPmText,
-    String? switchPmParameter,
+    InlineQueryResultsButton? button,
   }) async {
     Map<String, dynamic> params = {
       "inline_query_id": inlineQueryId,
@@ -2761,8 +2762,7 @@ class RawAPI {
       "cache_time": cacheTime,
       "is_personal": isPersonal,
       "next_offset": nextOffset,
-      "switch_pm_text": switchPmText,
-      "switch_pm_parameter": switchPmParameter,
+      "button": button?.toJson(),
     };
 
     bool response = await HttpClient.getURI(

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -3379,4 +3379,37 @@ class RawAPI {
 
     return response;
   }
+
+  /// Use this method to change the bot's name. Returns True on success.
+  ///
+  /// Since Bot API 6.7
+  Future<bool> setMyName(String? name, String? languageCode) async {
+    Map<String, dynamic> params = {
+      "name": name,
+      "language_code": languageCode,
+    };
+
+    bool response = await HttpClient.postURI(
+      _buildUri("setMyName"),
+      params,
+    );
+
+    return response;
+  }
+
+  /// Use this method to get the current bot name for the given user language. Returns [BotName] on success.
+  Future<BotName> getMyName(String? languageCode) async {
+    Map<String, dynamic> params = {
+      "language_code": languageCode,
+    };
+
+    BotName response = BotName.fromJson(
+      await HttpClient.postURI(
+        _buildUri("getMyName"),
+        params,
+      ),
+    );
+
+    return response;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.6!
-version: 1.6.0
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
+version: 1.7.0
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
## Bot API 6.7 🤖
All changes from the Bot API 6.7 is implemented. 

## Breaking Change! ⚠️
The `answerInlineQuery` will no longer accept `switchPmParameter` or `switchPmText` parameters.