### PR TITLE
Support for Local Bot API Servers! 🌐

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.0
+- 🎖️ Televerse now supports listening to Local Bot API Server.
+- Added `Televerse.local` method to create a bot instance that listens to a local Bot API Server.
+- Added `RawAPI.local` method that can be used to create `RawAPI` instance that targets a local Bot API Server.
+- Added `LongPolling.allUpdates` method to listen to all updates. This is to simplify listening to all updates including the `chat_member` updates.
+- Updated `/example/test_bot.dart` file to reflect the changes.
 ## 1.7.2
 - [BREAKING] ⚠️ - The `chat` getter on the `ChatID` class is now replaced to be a method of the `ID` class, and renamed to `get()`.
 - This is to avoid confusion with the `chat` parameter in the `ChatID` class. 

--- a/example/local_bot.dart
+++ b/example/local_bot.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:televerse/televerse.dart';
+
+void main(List<String> args) {
+  /// Get the token from the environment variables.
+  final token = Platform.environment['BOT_TOKEN']!;
+
+  /// Use the [Bot.local] constructor to create a bot instance.
+  Bot bot = Bot.local(token);
+
+  /// Start polling and setup the handler for the `/start` command.
+  bot.start((ctx) {
+    ctx.reply('Hello, World!');
+  });
+}

--- a/example/test_bot.dart
+++ b/example/test_bot.dart
@@ -5,7 +5,10 @@ import 'package:televerse/televerse.dart';
 /// This is a general bot that tests different features of the library.
 void main() async {
   /// Creates the bot instance
-  final Bot bot = Bot(Platform.environment["BOT_TOKEN"]!);
+  final Bot bot = Bot(
+    Platform.environment["BOT_TOKEN"]!,
+    fetcher: LongPolling.allUpdates(),
+  );
 
   /// Starts the bot and sets up the /start command listener
   bot.start((ctx) {
@@ -62,6 +65,16 @@ void main() async {
 
     await ctx.reply(
       "Select one of ${poll.options.map((e) => e.text).join(', ')} to vote.",
+    );
+  });
+
+  bot.onUpdate(UpdateType.chatMember).listen((update) {
+    ChatMemberUpdated member = update.chatMember!;
+    ChatMember newMember = member.newChatMember;
+
+    bot.api.sendMessage(
+      ChatID(member.chat.id),
+      "Member Updated: ${newMember.user.firstName}: ${newMember.status}",
     );
   });
 }

--- a/lib/src/telegram/models/inline_query_result_location.dart
+++ b/lib/src/telegram/models/inline_query_result_location.dart
@@ -1,8 +1,6 @@
 part of models;
 
 /// Represents a location on a map. By default, the location will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the location.
-///
-///
 class InlineQueryResultLocation extends InlineQueryResult {
   /// Type of the result, always [InlineQueryResultType.location]
   @override

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -98,4 +98,23 @@ class LongPolling extends Fetcher {
       _doubleRetryDelay();
     }
   }
+
+  /// [LongPolling] with all updates allowed.
+  static LongPolling allUpdates({
+    int offset = 0,
+    int timeout = 30,
+    int limit = 100,
+  }) {
+    List<UpdateType> allowedUpdates = [
+      for (var type in UpdateType.values)
+        if (type != UpdateType.unknown) type
+    ];
+    print(allowedUpdates);
+    return LongPolling(
+      allowedUpdates: allowedUpdates,
+      offset: offset,
+      timeout: timeout,
+      limit: limit,
+    );
+  }
 }

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -2,14 +2,29 @@ part of televerse;
 
 /// Raw API for the Telegram Bot API.
 class RawAPI {
+  /// Default base URL for the Telegram API.
+  static const String defaultBase = "api.telegram.org";
+
+  /// Status of the RawAPI, true if it is local, false otherwise.
+  final bool _isLocal;
+
   /// The Bot Token.
   final String token;
 
   /// The Raw API.
-  const RawAPI(this.token);
+  const RawAPI(this.token, [String? baseUrl])
+      : _baseUrl = baseUrl ?? defaultBase,
+        _isLocal = baseUrl != defaultBase;
+
+  /// Creates a new RawAPI instance with the given [token] and [baseUrl].
+  ///
+  /// When using `RawAPI.local`, the [baseUrl] is set to `localhost:8081` by default.
+  factory RawAPI.local(String token, [String baseUrl = "localhost:8081"]) {
+    return RawAPI(token, baseUrl);
+  }
 
   /// Base URL for the Telegram API.
-  final String _baseUrl = "api.telegram.org";
+  final String _baseUrl;
 
   /// Build the URI for the Telegram API.
   Uri _buildUri(String method, [Map<String, dynamic>? params]) {
@@ -20,7 +35,12 @@ class RawAPI {
       return MapEntry(key, "$value");
     });
     params?.removeWhere((key, value) => value == null || value == "null");
-    Uri uri = Uri.https(_baseUrl, "/bot$token/$method", params);
+    Uri uri;
+    if (_isLocal) {
+      uri = Uri.http(_baseUrl, "/bot$token/$method", params);
+    } else {
+      uri = Uri.https(_baseUrl, "/bot$token/$method", params);
+    }
     return uri;
   }
 

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -17,8 +17,14 @@ part of televerse;
 ///
 /// The [Televerse] class extends [Event] class. The [Event] class is used to emit events and additionally provides a bunch of useful methods.
 class Televerse extends Event with OnEvent {
-  /// Bot token.
-  static late String _botToken;
+  /// The current bot instance.
+  static late Televerse _instance;
+
+  /// Base URL of the Telegram Bot API.
+  final String _baseURL;
+
+  /// A flag that indicates whether the Bot API is running locally or not.
+  final bool isLocal;
 
   /// Handler for unexpected errors.
   FutureOr<void> Function(Object, StackTrace)? _onError;
@@ -33,7 +39,7 @@ class Televerse extends Event with OnEvent {
   ///   - DO NOT use this getter to create a bot instance. Use the [Televerse] constructor instead. This getter is only used to access the bot instance.
   static Televerse get instance {
     try {
-      return Televerse(_botToken);
+      return _instance;
     } catch (err) {
       throw TeleverseException(
         "Bot instance not found. ",
@@ -52,7 +58,10 @@ class Televerse extends Event with OnEvent {
   /// ```
   ///
   RawAPI get api {
-    return RawAPI(token);
+    if (isLocal) {
+      return RawAPI.local(token, _baseURL);
+    }
+    return RawAPI(token, _baseURL);
   }
 
   /// The fetcher - used to fetch updates from the Telegram servers.
@@ -69,14 +78,18 @@ class Televerse extends Event with OnEvent {
   /// If [sync] is true, events may be fired directly by the stream's subscriptions during an [StreamController.add], [StreamController.addError] or [StreamController.close] call. The returned stream controller is a [SynchronousStreamController], and must be used with the care and attention necessary to not break the [Stream] contract. See [Completer.sync] for some explanations on when a synchronous dispatching can be used. If in doubt, keep the controller non-sync.
   ///
   /// If [sync] is false, the event will always be fired at a later time, after the code adding the event has completed. In that case, no guarantees are given with regard to when multiple listeners get the events, except that each listener will get all events in the correct order. Each subscription handles the events individually. If two events are sent on an async controller with two listeners, one of the listeners may get both events before the other listener gets any. A listener must be subscribed both when the event is initiated (that is, when [add] is called) and when the event is later delivered, in order to receive the event.
+  ///
+  /// You can optionally pass a [baseURL] to the constructor. The [baseURL] is the base URL of the Telegram Bot API. By default, the base URL is `api.telegram.org`. This is useful when you are using a proxy server or a local server.
   Televerse(
     this.token, {
     Fetcher? fetcher,
     super.sync,
-  }) {
+    String baseURL = RawAPI.defaultBase,
+  })  : _baseURL = baseURL,
+        isLocal = baseURL != RawAPI.defaultBase {
     this.fetcher = fetcher ?? LongPolling();
     this.fetcher.setApi(api);
-    _botToken = token;
+    _instance = this;
 
     api.getMe().then((value) {
       _me = value;
@@ -87,6 +100,43 @@ class Televerse extends Event with OnEvent {
         throw err;
       }
     });
+  }
+
+  /// Televerse local constructor. This constructor is used to create a bot instance that listens to a local Bot API server.
+  ///
+  /// [token] - Bot token.
+  ///
+  /// [baseURL] - Base URL of the Telegram Bot API. By default, the base URL is `localhost:8081`. This parameter will be used to create the [RawAPI] instance that points to your local Bot API server.
+  ///
+  /// [fetcher] - The fetcher - used to fetch updates from the Telegram servers. By default, the bot uses long polling to fetch updates. You can also use webhooks to fetch updates.
+  ///
+  /// ## Note
+  /// The Bot API server source code is available at [telegram-bot-api](https://github.com/tdlib/telegram-bot-api). You can run it locally and send the requests to your own server instead of ```https://api.telegram.org```.
+  ///
+  /// If you switch to a local Bot API server, your bot will be able to:
+  /// - Download files without a size limit.
+  /// - Upload files up to 2000 MB.
+  /// - Upload files using their local path and the file URI scheme.
+  /// - Use an HTTP URL for the webhook.
+  /// - Use any local IP address for the webhook.
+  /// - Use any port for the webhook.
+  /// - Set max_webhook_connections up to 100000.
+  /// - Receive the absolute local path as a value of the file_path field without the need to download the file after a getFile request.
+  ///
+  /// Learn to setup Local Bot API Server here: https://github.com/tdlib/telegram-bot-api
+  factory Televerse.local(
+    String token, {
+    Fetcher? fetcher,
+    bool sync = false,
+    String baseURL = "localhost:8081",
+  }) {
+    print('Using local Bot API server at $baseURL');
+    return Televerse(
+      token,
+      fetcher: fetcher,
+      baseURL: baseURL,
+      sync: sync,
+    );
   }
 
   /// Information about the bot.

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -17,6 +17,9 @@ part of televerse;
 ///
 /// The [Televerse] class extends [Event] class. The [Event] class is used to emit events and additionally provides a bunch of useful methods.
 class Televerse extends Event with OnEvent {
+  /// API Scheme
+  final APIScheme _scheme;
+
   /// The current bot instance.
   static late Televerse _instance;
 
@@ -59,9 +62,9 @@ class Televerse extends Event with OnEvent {
   ///
   RawAPI get api {
     if (isLocal) {
-      return RawAPI.local(token, _baseURL);
+      return RawAPI.local(token, baseUrl: _baseURL, scheme: _scheme);
     }
-    return RawAPI(token, _baseURL);
+    return RawAPI(token, baseUrl: _baseURL, scheme: APIScheme.https);
   }
 
   /// The fetcher - used to fetch updates from the Telegram servers.
@@ -79,14 +82,20 @@ class Televerse extends Event with OnEvent {
   ///
   /// If [sync] is false, the event will always be fired at a later time, after the code adding the event has completed. In that case, no guarantees are given with regard to when multiple listeners get the events, except that each listener will get all events in the correct order. Each subscription handles the events individually. If two events are sent on an async controller with two listeners, one of the listeners may get both events before the other listener gets any. A listener must be subscribed both when the event is initiated (that is, when [add] is called) and when the event is later delivered, in order to receive the event.
   ///
-  /// You can optionally pass a [baseURL] to the constructor. The [baseURL] is the base URL of the Telegram Bot API. By default, the base URL is `api.telegram.org`. This is useful when you are using a proxy server or a local server.
+  /// ## Using Local Bot API Server
+  /// You can use the [Televerse] class to create a bot instance that listens to a local Bot API server. Use the [Televerse.local] constructor to create a bot instance that listens to a local Bot API server.
+  ///
+  /// You can pass the [baseURL] parameter to the constructor to specify the base URL of the Telegram Bot API. By default, the base URL is `api.telegram.org`. This parameter will be used to create the [RawAPI] instance that points to your local Bot API server.
+  /// If you're running the Bot API server locally, you should pass the [baseURL] and the [scheme] parameters to the constructor.
   Televerse(
     this.token, {
     Fetcher? fetcher,
     super.sync,
     String baseURL = RawAPI.defaultBase,
+    APIScheme scheme = APIScheme.https,
   })  : _baseURL = baseURL,
-        isLocal = baseURL != RawAPI.defaultBase {
+        isLocal = baseURL != RawAPI.defaultBase,
+        _scheme = scheme {
     this.fetcher = fetcher ?? LongPolling();
     this.fetcher.setApi(api);
     _instance = this;
@@ -110,6 +119,8 @@ class Televerse extends Event with OnEvent {
   ///
   /// [fetcher] - The fetcher - used to fetch updates from the Telegram servers. By default, the bot uses long polling to fetch updates. You can also use webhooks to fetch updates.
   ///
+  /// [scheme] - The scheme of the Telegram Bot API. By default, the scheme is `APIScheme.http`.
+  ///
   /// ## Note
   /// The Bot API server source code is available at [telegram-bot-api](https://github.com/tdlib/telegram-bot-api). You can run it locally and send the requests to your own server instead of ```https://api.telegram.org```.
   ///
@@ -129,6 +140,7 @@ class Televerse extends Event with OnEvent {
     Fetcher? fetcher,
     bool sync = false,
     String baseURL = "localhost:8081",
+    APIScheme scheme = APIScheme.http,
   }) {
     print('Using local Bot API server at $baseURL');
     return Televerse(
@@ -136,6 +148,7 @@ class Televerse extends Event with OnEvent {
       fetcher: fetcher,
       baseURL: baseURL,
       sync: sync,
+      scheme: scheme,
     );
   }
 

--- a/lib/src/types/bot_command_scope_type.dart
+++ b/lib/src/types/bot_command_scope_type.dart
@@ -1,13 +1,13 @@
 part of types;
 
 /// This object represents the scope to which bot commands are applied. Currently, the following 7 scopes are supported:
-/// - [BotCommandScopeType.defaultScope]: The default scope. Default commands are used if no commands with a narrower scope are specified for the user.
-/// - [BotCommandScopeType.allPrivateChats]: All private chats.
-/// - [BotCommandScopeType.allGroupChats]: All group and supergroup chats.
-/// - [BotCommandScopeType.allChatAdministrators]: All group and supergroup chat administrators.
-/// - [BotCommandScopeType.chat]: A specific chat.
-/// - [BotCommandScopeType.chatAdministrators]: All administrators of a specific group or supergroup chat.
-/// - [BotCommandScopeType.chatMember]: A specific member of a group or supergroup chat.
+/// - [BotCommandScopeType.defaultScope] : The default scope. Default commands are used if no commands with a narrower scope are specified for the user.
+/// - [BotCommandScopeType.allPrivateChats] : All private chats.
+/// - [BotCommandScopeType.allGroupChats] : All group and supergroup chats.
+/// - [BotCommandScopeType.allChatAdministrators] : All group and supergroup chat administrators.
+/// - [BotCommandScopeType.chat] : A specific chat.
+/// - [BotCommandScopeType.chatAdministrators] : All administrators of a specific group or supergroup chat.
+/// - [BotCommandScopeType.chatMember] : A specific member of a group or supergroup chat.
 enum BotCommandScopeType {
   /// The default scope. Default commands are used if no commands with a narrower scope are specified for the user.
   defaultScope("default"),

--- a/lib/src/types/chat_type.dart
+++ b/lib/src/types/chat_type.dart
@@ -1,11 +1,11 @@
 part of types;
 
 /// This object represents type of a chat. Currently, the following 5 types are supported:
-/// - [ChatType.private]: For a private chat with a user
-/// - [ChatType.group]: For a group chat
-/// - [ChatType.supergroup]: For a supergroup chat
-/// - [ChatType.channel]: For a channel chat
-/// - [ChatType.sender]: For a private chat with the inline query sender
+/// - [ChatType.private] : For a private chat with a user
+/// - [ChatType.group] : For a group chat
+/// - [ChatType.supergroup] : For a supergroup chat
+/// - [ChatType.channel] : For a channel chat
+/// - [ChatType.sender] : For a private chat with the inline query sender
 enum ChatType {
   /// For a private chat with a user
   private("private"),

--- a/lib/src/types/input_file_type.dart
+++ b/lib/src/types/input_file_type.dart
@@ -2,9 +2,9 @@ part of types;
 
 /// This object represents the type of a file to send.
 /// Currently, the following 3 types are supported:
-/// - [InputFileType.fileId]: For a file sent as a file_id
-/// - [InputFileType.file]: For a file sent as a file
-/// - [InputFileType.url]: For a file sent as a url
+/// - [InputFileType.fileId] : For a file sent as a file_id
+/// - [InputFileType.file] : For a file sent as a file
+/// - [InputFileType.url] : For a file sent as a url
 ///
 /// Check out the [InputFile] class for more information.
 enum InputFileType {

--- a/lib/src/types/input_media_type.dart
+++ b/lib/src/types/input_media_type.dart
@@ -2,11 +2,11 @@ part of types;
 
 /// This object represents the type of a media to send.
 /// Currently, the following 5 types are supported:
-/// - [InputMediaType.animation]:For an animation file (GIF or H.264/MPEG-4 AVC video without sound) to send.
-/// - [InputMediaType.audio]: For an audio file to send.
-/// - [InputMediaType.document]:  For a general file to send.
-/// - [InputMediaType.photo]: For a photo to send.
-/// - [InputMediaType.video]: For a video file to send.
+/// - [InputMediaType.animation] :For an animation file (GIF or H.264/MPEG-4 AVC video without sound) to send.
+/// - [InputMediaType.audio] : For an audio file to send.
+/// - [InputMediaType.document] :  For a general file to send.
+/// - [InputMediaType.photo] : For a photo to send.
+/// - [InputMediaType.video] : For a video file to send.
 enum InputMediaType {
   /// For an animation file (GIF or H.264/MPEG-4 AVC video without sound) to send.
   animation("animation"),

--- a/lib/src/types/scheme.dart
+++ b/lib/src/types/scheme.dart
@@ -1,0 +1,23 @@
+part of types;
+
+/// API Scheme - HTTP or HTTPS.
+enum APIScheme {
+  /// HTTP
+  http,
+
+  /// HTTPS
+  https;
+
+  /// Returns the value of the scheme as [String].
+  String get value => toString().split('.').last;
+
+  bool isEqual(dynamic other) {
+    if (other is APIScheme) {
+      return other.value == value;
+    } else if (other is String) {
+      return other == value;
+    } else {
+      return false;
+    }
+  }
+}

--- a/lib/src/types/sticker_type.dart
+++ b/lib/src/types/sticker_type.dart
@@ -1,5 +1,11 @@
 part of types;
 
+/// A class that represents the type of a sticker.
+///
+/// Currently, there are three types of stickers:
+/// - Regular stickers
+/// - Mask stickers
+/// - Custom emoji stickers
 enum StickerType {
   /// A regular sticker.
   regular("regular"),

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -20,3 +20,4 @@ part 'message_entity_type.dart';
 part 'parse_mode.dart';
 part 'chat_action.dart';
 part 'sticker_format.dart';
+part 'scheme.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
-version: 1.7.2
+version: 1.8.1
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
Since the Bot API Server code is open source and using a local Bot API Server increases the performance of the Telegram bots it's important for a Telegram Bot API wrapper to support listening to local servers.

With this update, Televerse can now support listening to local Bot API servers. The `Televerse` constructor now supports passing a `baseURL` and a `scheme` which acts as the `baseURL` instead of the default `api.telegram.org` address.

To further simplify this you can now use the `Televerse.local` constructor to create bots that listen to the local Bot API servers.