### PR TITLE
ChatMemberUpdated Listeners 🎧

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.8.1
+- Added `ChatMemberUpdatedContext` class to represent the context of a `chat_member` and `my_chat_member` updates.
+- Hot fix: Fixed an issue with the `Event` class that caused unexpected exceptions.
 ## 1.8.0
 - 🎖️ Televerse now supports listening to Local Bot API Server.
 - Added `Televerse.local` method to create a bot instance that listens to a local Bot API Server.

--- a/lib/src/televerse/context/chat_member.dart
+++ b/lib/src/televerse/context/chat_member.dart
@@ -1,0 +1,86 @@
+part of televerse.context;
+
+/// This context is created when a chat member is updated. This can be used to handle chat member updates.
+///
+/// This is used to handle the `chatMemberUpdated` and `myChatMemberUpdated` updates.
+class ChatMemberUpdatedContext extends Context
+    with ManagementMixin, MessageMixin {
+  /// Creates a new [ChatMemberUpdatedContext] instance.
+  ChatMemberUpdatedContext(
+    super.api, {
+    required super.update,
+  });
+
+  /// The [ChatMemberUpdated] instance.
+  ChatMemberUpdated get chatMemberUpdated => update.chatMember!;
+
+  /// The old chat member.
+  ChatMember get oldChatMember => chatMemberUpdated.oldChatMember;
+
+  /// The new chat member.
+  ChatMember get newChatMember => chatMemberUpdated.newChatMember;
+
+  /// The [User] instance of the updated chat member.
+  User get user => newChatMember.user;
+
+  /// The ID of the updated chat member.
+  ID get userID => ChatID(user.id);
+
+  /// Flag that indicates whether the chat member is the bot.
+  bool get isBot => user.isBot;
+
+  /// Current status of the chat member.
+  ChatMemberStatus get status => newChatMember.status;
+
+  /// Old status of the chat member.
+  ChatMemberStatus get oldStatus => oldChatMember.status;
+
+  /// A flag that indicates whether the chat member is a creator.
+  bool get isCreator => status == ChatMemberStatus.creator;
+
+  /// A flag that indicates whether the chat member is an administrator.
+  bool get isAdministrator => status == ChatMemberStatus.administrator;
+
+  /// A flag that indicates whether the chat member is a member.
+  bool get isMember => status == ChatMemberStatus.member;
+
+  /// A flag that indicates whether the chat member is restricted.
+  bool get isRestricted => status == ChatMemberStatus.restricted;
+
+  /// A flag that indicates whether the chat member is left.
+  bool get isLeft => status == ChatMemberStatus.left;
+
+  /// A flag that indicates whether the chat member is kicked.
+  bool get isKicked => status == ChatMemberStatus.kicked;
+
+  /// Send a message to the updated chat member.
+  ///
+  /// This will only work if the user has started a chat with the bot.
+  /// If the user has not started a chat with the bot, this will throw a [TeleverseException].
+  Future<Message> replyToUser(
+    String text, {
+    int? messageThreadId,
+    ParseMode? parseMode,
+    List<MessageEntity>? entities,
+    bool? disableWebPagePreview,
+    bool? disableNotification,
+    bool? protectContent,
+    int? replyToMessageId,
+    bool? allowSendingWithoutReply,
+    ReplyMarkup? replyMarkup,
+  }) async {
+    return await api.sendMessage(
+      userID,
+      text,
+      messageThreadId: messageThreadId,
+      parseMode: parseMode,
+      entities: entities,
+      disableWebPagePreview: disableWebPagePreview,
+      disableNotification: disableNotification,
+      protectContent: protectContent,
+      replyToMessageId: replyToMessageId,
+      allowSendingWithoutReply: allowSendingWithoutReply,
+      replyMarkup: replyMarkup,
+    );
+  }
+}

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -55,6 +55,7 @@ part 'mixins/management.dart';
 part 'message.dart';
 part 'inline_query.dart';
 part 'callback_query.dart';
+part 'chat_member.dart';
 
 /// This class is used to represent the context of an update. It contains the update and the [RawAPI] instance.
 ///

--- a/lib/src/televerse/event/event.dart
+++ b/lib/src/televerse/event/event.dart
@@ -14,6 +14,12 @@ part 'on.dart';
 ///
 /// You probably won't need to use this class directly, but you can use it to handle events.
 class Event {
+  /// The [RawAPI] instance.
+  late final RawAPI _api;
+
+  /// Set the [RawAPI] instance.
+  set api(RawAPI api) => _api = api;
+
   /// If [sync] is true, events may be fired directly by the stream's subscriptions during an [StreamController.add], [StreamController.addError] or [StreamController.close] call. The returned stream controller is a [SynchronousStreamController], and must be used with the care and attention necessary to not break the [Stream] contract. See [Completer.sync] for some explanations on when a synchronous dispatching can be used. If in doubt, keep the controller non-sync.
   ///
   /// If [sync] is false, the event will always be fired at a later time, after the code adding the event has completed. In that case, no guarantees are given with regard to when multiple listeners get the events, except that each listener will get all events in the correct order. Each subscription handles the events individually. If two events are sent on an async controller with two listeners, one of the listeners may get both events before the other listener gets any. A listener must be subscribed both when the event is initiated (that is, when [add] is called) and when the event is later delivered, in order to receive the event.
@@ -82,13 +88,13 @@ class Event {
       ).map(_mapper<PollAnswer>);
 
   /// **onMyChatMember** is a stream of [ChatMemberUpdated] which is emitted when the bot's chat member status is updated.
-  Stream<ChatMemberUpdated> get onMyChatMember =>
-      onUpdate(UpdateType.myChatMember).map(_mapper<ChatMemberUpdated>);
+  Stream<ChatMemberUpdatedContext> get onMyChatMember =>
+      onUpdate(UpdateType.myChatMember).map(_mapper<ChatMemberUpdatedContext>);
 
   /// **onChatMember** is a stream of [ChatMemberUpdated] which is emitted when a chat member's status is updated.
-  Stream<ChatMemberUpdated> get onChatMember => onUpdate(
+  Stream<ChatMemberUpdatedContext> get onChatMember => onUpdate(
         UpdateType.chatMember,
-      ).map(_mapper<ChatMemberUpdated>);
+      ).map(_mapper<ChatMemberUpdatedContext>);
 
   /// **onChatJoinRequest** is a stream of [ChatJoinRequest] which is emitted when a user requests to join a chat.
   Stream<ChatJoinRequest> get onChatJoinRequest =>
@@ -110,7 +116,7 @@ class Event {
   T _mapper<T>(Update update) {
     if (T == MessageContext && update.type == UpdateType.message) {
       return MessageContext(
-        Televerse.instance.api,
+        _api,
         update.message!,
         update: update,
       ) as T;
@@ -118,7 +124,7 @@ class Event {
 
     if (T == MessageContext && update.type == UpdateType.editedMessage) {
       return MessageContext(
-        Televerse.instance.api,
+        _api,
         update.editedMessage!,
         update: update,
       ) as T;
@@ -126,7 +132,7 @@ class Event {
 
     if (T == MessageContext && update.type == UpdateType.channelPost) {
       return MessageContext(
-        Televerse.instance.api,
+        _api,
         update.channelPost!,
         update: update,
       ) as T;
@@ -134,7 +140,7 @@ class Event {
 
     if (T == MessageContext && update.type == UpdateType.editedChannelPost) {
       return MessageContext(
-        Televerse.instance.api,
+        _api,
         update.editedChannelPost!,
         update: update,
       ) as T;
@@ -142,7 +148,7 @@ class Event {
 
     if (T == InlineQueryContext) {
       return InlineQueryContext(
-        Televerse.instance.api,
+        _api,
         update.inlineQuery!,
         update: update,
       ) as T;
@@ -150,7 +156,7 @@ class Event {
 
     if (T == CallbackQueryContext) {
       return CallbackQueryContext(
-        Televerse.instance.api,
+        _api,
         update.callbackQuery!,
         update: update,
       ) as T;
@@ -176,12 +182,19 @@ class Event {
       return update.pollAnswer! as T;
     }
 
-    if (T == ChatMemberUpdated && update.type == UpdateType.myChatMember) {
-      return update.myChatMember! as T;
+    if (T == ChatMemberUpdatedContext &&
+        update.type == UpdateType.myChatMember) {
+      return ChatMemberUpdatedContext(
+        _api,
+        update: update,
+      ) as T;
     }
 
-    if (T == ChatMemberUpdated && update.type == UpdateType.chatMember) {
-      return update.chatMember! as T;
+    if (T == ChatMemberUpdatedContext && update.type == UpdateType.chatMember) {
+      return ChatMemberUpdatedContext(
+        _api,
+        update: update,
+      ) as T;
     }
 
     if (T == ChatJoinRequest) {

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -99,6 +99,7 @@ class Televerse extends Event with OnEvent {
     this.fetcher = fetcher ?? LongPolling();
     this.fetcher.setApi(api);
     _instance = this;
+    super.api = api;
 
     api.getMe().then((value) {
       _me = value;

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -482,4 +482,74 @@ class Televerse extends Event with OnEvent {
       }
     });
   }
+
+  /// Registers callback for the [ChatMemberUpdated] events
+  void _internalChatMemberUpdatedHandling({
+    required Stream<ChatMemberUpdatedContext> stream,
+    required ChatMemberUpdatedHandler callback,
+    ChatMemberStatus? oldStatus,
+    ChatMemberStatus? newStatus,
+  }) {
+    stream.listen((ChatMemberUpdatedContext context) {
+      if (oldStatus == null && newStatus == null) {
+        callback(context);
+        return;
+      }
+      if (oldStatus != null && newStatus != null) {
+        if (context.oldStatus == oldStatus && context.status == newStatus) {
+          callback(context);
+        }
+        return;
+      }
+      if (oldStatus != null) {
+        if (context.oldStatus == oldStatus) {
+          callback(context);
+        }
+        return;
+      }
+      if (newStatus != null) {
+        if (context.status == newStatus) {
+          callback(context);
+        }
+        return;
+      }
+    });
+  }
+
+  /// Registers a callback for the [Update.chatMember] events.
+  ///
+  /// If you want to receive the Chat Member updates, you must explicitly specify
+  /// the `UpdateType.chatMember` in the [LongPolling.allowedUpdates] property.
+  ///
+  /// You can optionally specify [ChatMemberStatus] to [oldStatus] and [newStatus]
+  /// filter to only receive updates for a specific status.
+  void chatMember({
+    required ChatMemberUpdatedHandler callback,
+    ChatMemberStatus? oldStatus,
+    ChatMemberStatus? newStatus,
+  }) {
+    return _internalChatMemberUpdatedHandling(
+      stream: onChatMember,
+      callback: callback,
+      oldStatus: oldStatus,
+      newStatus: newStatus,
+    );
+  }
+
+  /// Registers a callback for the [Update.myChatMember] events.
+  ///
+  /// You can optionally specify [ChatMemberStatus] to [oldStatus] and [newStatus]
+  /// filter to only receive updates for a specific status.
+  void myChatMember({
+    required ChatMemberUpdatedHandler callback,
+    ChatMemberStatus? oldStatus,
+    ChatMemberStatus? newStatus,
+  }) {
+    return _internalChatMemberUpdatedHandling(
+      stream: onMyChatMember,
+      callback: callback,
+      oldStatus: oldStatus,
+      newStatus: newStatus,
+    );
+  }
 }

--- a/lib/src/types/aliases.dart
+++ b/lib/src/types/aliases.dart
@@ -15,3 +15,9 @@ typedef CallbackQueryHandler = FutureOr<void> Function(
 ///
 /// This is used to define a callback function for almost all the methods that listen to inline queries.
 typedef InlineQueryHandler = FutureOr<void> Function(InlineQueryContext ctx);
+
+/// [ChatMemberUpdatedHandler] is a type alias for a function that takes a [ChatMemberUpdatedContext] as parameter and returns a [FutureOr] of void.
+///
+/// This is used to define a callback function for almost all the methods that listen to chat member updates.
+typedef ChatMemberUpdatedHandler = FutureOr<void> Function(
+    ChatMemberUpdatedContext ctx);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
-version: 1.8.0
+version: 1.8.1
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
## 1.8.1
- Added `ChatMemberUpdatedContext` class to represent the context of a `chat_member` and `my_chat_member` updates.
- Added `Televerse.chatMember` and `Televerse.myChatMember` methods to listen to `chat_member` and `my_chat_member` updates.
- Hotfix: Fixed an issue with the `Event` class that caused unexpected exceptions.