### PR TITLE
Instead of throwing, we ignore 🚣🏻‍♂️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.9.5
+## 1.9.6
 
 - Added `Televerse.onStop` to listen when the bot is stopped. (Fix [#95](https://github.com/HeySreelal/televerse/issues/95))
 - Added `delayDuration` parameter to `LongPolling` class to set the delay duration between each long polling request.

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -86,7 +86,7 @@ class LongPolling extends Fetcher {
       );
       for (var update in updates) {
         if (_updateStreamController.isClosed) {
-          throw LongPollingException.streamClosed;
+          return;
         }
         addUpdate(update);
         offset = update.updateId + 1;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
-version: 1.9.5
+version: 1.9.6
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
If new updates are received at the final requests after calling `bot.stop` we used to throw `LongPollingException.streamClosed` now we simply ignore it. 

