### PR TITLE
Handle telegram messages without fetcher

### DIFF
--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -226,6 +226,13 @@ class Televerse<TeleverseSession extends Session> {
   /// List of Handler Scopes
   final List<HandlerScope> _handlerScopes = [];
 
+  /// To manually handle updates without fetcher
+  ///
+  /// This method is useful when you want to use a custom webhook server instead of the default one provided by Televerse,
+  /// or to use in a cloud function.
+  /// use Update.fromJson(json) to convert the json to an update.
+  void handleUpdate(Update update) => _onUpdate(update);
+
   /// Start polling for updates.
   ///
   /// This method starts polling for updates. It will automatically start the fetcher.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.7 <4.0.0"
 
 dependencies:
-  http: 0.13.5
+  http: ^1.0.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.7 <4.0.0"
 
 dependencies:
-  http: ^1.0.0
+  http: 0.13.5
 
 dev_dependencies:
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.9.7
 homepage: https://github.com/HeySreelal/televerse
 
 environment:
-  sdk: ">=2.18.2 <4.0.0"
+  sdk: ">=2.17.7 <4.0.0"
 
 dependencies:
   http: ^1.0.0


### PR DESCRIPTION
This Pr adds capability to handle updates from telegram with our custom implementations

for example, from cloud functions , we cannot start longPolling or a webhook listener 
so there we can only listen to cloud function's entry point method
 so only option left is to get json data from that entry method and pass that into this library to handle it

and that's where this new api : `handleUpdate(Update)` is useful , so we can simply pass the update from this method instead of starting any fetcher

Also this Pr changed dart min sdk version to : `2.17.7` because that cloud function am talking about does not support upper dart sdk for now ( probably in future soon ), and for same reason also changed version of http library 
Which i guess no harm for now, because http latest version  uses Dart3 which makes it incompatible with older dart sdk's

 