### PR TITLE
Fixes #108 & #110 🔐

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.12
+
+- Fixes the issue which caused the crash of bots when a `ChatJoinRequest` update is received.
+- Thanks to @iamcosmin for taking effort to fix this issue. [#109](https://github.com/HeySreelal/televerse/pull/109)
+- The `messageThreadId` parameter noww be defaulted to the `messageThreadId` parameter in the incoming `Context` object on `reply` method.
+- This is to make it easier to reply to a message when the discussion is on a Forum Topic. (Fixes [#110](https://github.com/HeySreelal/televerse/issues/110))
+
 ## 1.9.11
 
 - Fixes an issue that caused none of `onEditedMessage`, `onChannelPost`, `onEditedChannelPost`, and `myChatMember` to work.

--- a/lib/src/telegram/models/chat_join_request.dart
+++ b/lib/src/telegram/models/chat_join_request.dart
@@ -6,7 +6,7 @@ class ChatJoinRequest {
   final Chat chat;
 
   /// User that sent the join request
-  final User user;
+  final User from;
 
   /// Date the request was sent in Unix time
   ///
@@ -27,7 +27,7 @@ class ChatJoinRequest {
   /// Creates a new [ChatJoinRequest] object.
   const ChatJoinRequest({
     required this.chat,
-    required this.user,
+    required this.from,
     required this.date,
     this.bio,
     this.inviteLink,
@@ -38,7 +38,7 @@ class ChatJoinRequest {
   factory ChatJoinRequest.fromJson(Map<String, dynamic> json) {
     return ChatJoinRequest(
       chat: Chat.fromJson(json['chat']),
-      user: User.fromJson(json['user']),
+      from: User.fromJson(json['from']),
       date: json['date'],
       bio: json['bio'],
       inviteLink: json['invite_link'] == null
@@ -52,7 +52,7 @@ class ChatJoinRequest {
   Map<String, dynamic> toJson() {
     return {
       'chat': chat.toJson(),
-      'user': user.toJson(),
+      'from': from.toJson(),
       'date': date,
       'bio': bio,
       'invite_link': inviteLink?.toJson(),
@@ -62,4 +62,7 @@ class ChatJoinRequest {
 
   /// Returns a [DateTime] object representing the [date] field
   DateTime get dateTime => DateTime.fromMillisecondsSinceEpoch(date * 1000);
+
+  /// User that sent the join request (alias for [from])
+  User get user => from;
 }

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -6,9 +6,6 @@ class Message {
   final int messageId;
 
   /// Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
-  final int? threadId;
-
-  /// Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
   final int? messageThreadId;
 
   /// Optional. Sender of the message; empty for messages sent to channels. For backward compatibility, the field contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
@@ -290,7 +287,6 @@ class Message {
     this.isAutomaticForward,
     this.isTopicMessage,
     this.messageThreadId,
-    this.threadId,
     this.userShared,
     this.chatShared,
     this.hasMediaSpoiler,
@@ -427,7 +423,6 @@ class Message {
           : ForumTopicReopened.fromJson(json['forum_topic_reopened']),
       hasProtectedContent: json['has_protected_content'],
       isTopicMessage: json['is_topic_message'],
-      threadId: json['thread_id'],
       messageThreadId: json['message_thread_id'],
       userShared: json['user_shared'] == null
           ? null
@@ -520,7 +515,6 @@ class Message {
       'forum_topic_reopened': forumTopicReopened?.toJson(),
       'has_protected_content': hasProtectedContent,
       'is_topic_message': isTopicMessage,
-      'thread_id': threadId,
       'message_thread_id': messageThreadId,
       'user_shared': userShared?.toJson(),
       'chat_shared': chatShared?.toJson(),

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -110,8 +110,6 @@ class Context {
   /// The Session setter.
   set session(Session session) {
     _bot.sessions.addSession(id.id, _session);
-
-    print(_bot.sessions.toJson());
   }
 
   /// The [ChatID] instance.

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -25,7 +25,7 @@ mixin MessageMixin on Context {
     return await api.sendMessage(
       id,
       text,
-      messageThreadId: messageThreadId,
+      messageThreadId: messageThreadId ?? _msg.messageThreadId,
       parseMode: parseMode,
       entities: entities,
       disableWebPagePreview: disableWebPagePreview,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
-version: 1.9.11
+version: 1.9.12
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
- The `reply` method will now automatically reply to the user on the same topic as the incoming message.
- Fixed the issue that caused the bot to crash when a `ChatJoinRequest` update is received.