### PR TITLE
👩🏻‍🔧 Fix: `onError` rethrows exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.14
+
+- Fixed a critical issue that caused bots to crash when an exception other than `TelegramException` is thrown.
+- The weird thing was that the `onError` method was able to catch the exception but it rethrows it again.
+- This is now fixed and the `onError` method will not rethrow the exception.
+- Thanks to [@GiuseppeFn](https://github.com/GiuseppeFn) for raising this.
+
 ## 1.9.13
 
 - Added a whole bunch of helper methods to listen to updates.

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -116,8 +116,8 @@ class LongPolling extends Fetcher {
           await _onError!(err, stackTrace);
         } else {
           _doubleRetryDelay();
+          rethrow;
         }
-        rethrow;
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 6.7!
-version: 1.9.13
+version: 1.9.14
 homepage: https://github.com/HeySreelal/televerse
 
 environment:


### PR DESCRIPTION
Like nothing else in this universe, after catching an exception, onError is used to rethrow it unless it was a `TelegramException`.