### PR TITLE
Added ctx.bot.

### DIFF
--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -87,6 +87,9 @@ class Context {
   /// The RawAPI getter.
   RawAPI get api => _bot.api;
 
+  /// The bot that received the update's informations.
+  User get bot => _bot.me;
+
   /// The RawAPI instance.
   final Televerse _bot;
 

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -88,7 +88,7 @@ class Context {
   RawAPI get api => _bot.api;
 
   /// The bot that received the update's informations.
-  User get bot => _bot.me;
+  User get me => _bot.me;
 
   /// The RawAPI instance.
   final Televerse _bot;


### PR DESCRIPTION
We noticed that sometimes, it would be really useful to know which bot received the update, without everytime doing ctx.api.getMe() or some other workaround. After a discussion we decided to not expose ctx.bot and expose a ctx.me.