### PR TITLE
Introducing Menu 🎲

### DIFF
--- a/example/menu_bot.dart
+++ b/example/menu_bot.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+import 'package:televerse/televerse.dart';
+
+/// This is a general bot that tests different features of the library.
+void main() async {
+  /// Creates the bot instance
+  final bot = Bot(Platform.environment["BOT_TOKEN"]!);
+
+  bot.start((ctx) {
+    // Create the menu
+    final menu = InlineMenu()
+        .text("Hello", (ctx) => ctx.answer(text: "Cool!"))
+        .row()
+        .text(
+          "Another",
+          (ctx) => ctx.answerWithAlert(text: "That's what you like :)"),
+        )
+        .text("Second", (ctx) => ctx.editMessage("How was that?"));
+
+    // Attach it to the bot
+    bot.attachMenu(menu);
+
+    // Reply with the menu
+    ctx.reply(
+      "Hello, choose an option:",
+      replyMarkup: menu,
+    );
+  });
+}

--- a/example/menu_bot.dart
+++ b/example/menu_bot.dart
@@ -4,15 +4,15 @@ import 'package:televerse/televerse.dart';
 /// Creates the bot instance
 final bot = Bot(Platform.environment["BOT_TOKEN"]!);
 
+// Create the menu
+final startMenu = InlineMenu(name: "Start Menu")
+    .text("Hello", helloCallback)
+    .row()
+    .text("Start", firstCallback)
+    .text("Finish", finishCallback);
+
 /// This is a general bot that tests different features of the library.
 void main() async {
-  // Create the menu
-  final startMenu = InlineMenu()
-      .text("Hello", helloCallback)
-      .row()
-      .text("Start", firstCallback)
-      .text("Finish", finishCallback);
-
   // Attach it to the bot
   bot.attachMenu(startMenu);
 
@@ -41,4 +41,7 @@ void firstCallback(CallbackQueryContext ctx) {
 // with "How was that?"
 void finishCallback(CallbackQueryContext ctx) {
   ctx.editMessage("How was that?");
+
+  // Removes the menu listeners from the bot
+  bot.removeMenu(startMenu);
 }

--- a/example/menu_bot.dart
+++ b/example/menu_bot.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 import 'package:televerse/televerse.dart';
 
+/// Creates the bot instance
+final bot = Bot(Platform.environment["BOT_TOKEN"]!);
+
 /// This is a general bot that tests different features of the library.
 void main() async {
-  /// Creates the bot instance
-  final bot = Bot(Platform.environment["BOT_TOKEN"]!);
-
   // Create the menu
   final startMenu = InlineMenu()
       .text("Hello", helloCallback)

--- a/example/menu_bot.dart
+++ b/example/menu_bot.dart
@@ -6,24 +6,39 @@ void main() async {
   /// Creates the bot instance
   final bot = Bot(Platform.environment["BOT_TOKEN"]!);
 
+  // Create the menu
+  final startMenu = InlineMenu()
+      .text("Hello", helloCallback)
+      .row()
+      .text("Start", firstCallback)
+      .text("Finish", finishCallback);
+
+  // Attach it to the bot
+  bot.attachMenu(startMenu);
+
+  // Start the bot and listen for /start command updates
   bot.start((ctx) {
-    // Create the menu
-    final menu = InlineMenu()
-        .text("Hello", (ctx) => ctx.answer(text: "Cool!"))
-        .row()
-        .text(
-          "Another",
-          (ctx) => ctx.answerWithAlert(text: "That's what you like :)"),
-        )
-        .text("Second", (ctx) => ctx.editMessage("How was that?"));
-
-    // Attach it to the bot
-    bot.attachMenu(menu);
-
     // Reply with the menu
     ctx.reply(
       "Hello, choose an option:",
-      replyMarkup: menu,
+      replyMarkup: startMenu,
     );
   });
+}
+
+// When a user clicks on the "Hello" button, the bot will answer with "Cool!"
+void helloCallback(CallbackQueryContext ctx) {
+  ctx.answer(text: "Cool!");
+}
+
+// When a user clicks on the "First" button, the bot will answer with
+// "That's what you like :)" in an alert
+void firstCallback(CallbackQueryContext ctx) {
+  ctx.answerWithAlert(text: "That's what you like :)");
+}
+
+// When a user clicks on the "Second" button, the bot will edit the message
+// with "How was that?"
+void finishCallback(CallbackQueryContext ctx) {
+  ctx.editMessage("How was that?");
 }

--- a/lib/src/conversation/conversation.dart
+++ b/lib/src/conversation/conversation.dart
@@ -241,7 +241,7 @@ class Conversation<T extends Session> {
 
     final scopeName = "conversation+${_getRandomID()}";
     _bot._handlerScopes.add(
-      HandlerScope<DC Function(DC)>(
+      HandlerScope<FutureOr<void> Function(DC)>(
         isConversation: true,
         name: scopeName,
         predicate: (ctx) =>
@@ -268,15 +268,5 @@ class Conversation<T extends Session> {
     _bot._handlerScopes.removeWhere((scope) => scope.name == scopeName);
 
     return ctx;
-  }
-
-  // Internal method to generate a random id.
-  // Include a-z, A-Z, 0-9
-  String _getRandomID() {
-    final random = Random();
-    final chars =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    return List.generate(20, (index) => chars[random.nextInt(chars.length)])
-        .join();
   }
 }

--- a/lib/src/televerse/markups/inline_keyboard.dart
+++ b/lib/src/televerse/markups/inline_keyboard.dart
@@ -67,14 +67,17 @@ class InlineKeyboard extends InlineKeyboardMarkup {
 
   /// Adds a new row to the current keyboard.
   InlineKeyboard row() {
+    if (inlineKeyboard.last.isEmpty) return this;
     inlineKeyboard.add([]);
     return this;
   }
 
   /// Adds a Inline Keyboard Button with given [text] and [data] to the current row.
   InlineKeyboard add(String text, String data) {
-    inlineKeyboard.last
-        .add(InlineKeyboardButton(text: text, callbackData: data));
+    inlineKeyboard.last.add(InlineKeyboardButton(
+      text: text,
+      callbackData: data,
+    ));
     return this;
   }
 

--- a/lib/src/televerse/markups/inline_menu.dart
+++ b/lib/src/televerse/markups/inline_menu.dart
@@ -1,0 +1,55 @@
+part of televerse;
+
+/// This object represents a Inline Keyboard with the action to be done.
+class InlineMenu implements InlineKeyboardMarkup {
+  /// Map that represents the text and action to be done
+  List<Map<String, CallbackQueryHandler>> actions;
+
+  /// Constructs a InlineMenu
+  InlineMenu([List<Map<String, CallbackQueryHandler>>? actions])
+      : actions = actions ?? [{}],
+        inlineKeyboard = _make(actions);
+
+  /// Add a new row to the keyboard
+  InlineMenu row() {
+    if (actions.last.isEmpty) return this;
+    actions.add({});
+    inlineKeyboard = _make(actions);
+    return this;
+  }
+
+  /// Add new item to the last row
+  InlineMenu text(String text, CallbackQueryHandler handler) {
+    if (actions.isEmpty) actions.add({});
+    actions.last.addAll({
+      text: handler,
+    });
+    inlineKeyboard = _make(actions);
+    return this;
+  }
+
+  @override
+  List<List<InlineKeyboardButton>> inlineKeyboard;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'inline_keyboard': inlineKeyboard.map((row) {
+        return row.map((button) {
+          return button.toJson();
+        }).toList();
+      }).toList(),
+    }..removeWhere((key, value) => value == null);
+  }
+
+  static List<List<InlineKeyboardButton>> _make(
+    List<Map<String, CallbackQueryHandler>>? rows,
+  ) {
+    if (rows == null) return [];
+    return rows.map((row) {
+      return row.keys.map((element) {
+        return InlineKeyboardButton(text: element, callbackData: element);
+      }).toList();
+    }).toList();
+  }
+}

--- a/lib/src/televerse/markups/inline_menu.dart
+++ b/lib/src/televerse/markups/inline_menu.dart
@@ -1,36 +1,46 @@
 part of televerse;
 
 /// This object represents a Inline Keyboard with the action to be done.
-class InlineMenu implements InlineKeyboardMarkup {
+class InlineMenu
+    implements
+        InlineKeyboardMarkup,
+        TeleverseMenu<CallbackQueryContext, CallbackQueryHandler> {
+  /// Name of the menu
+  @override
+  String? name;
+
   /// Map that represents the text and action to be done
+  @override
   List<Map<String, CallbackQueryHandler>> actions;
 
   /// Constructs a InlineMenu
-  InlineMenu([List<Map<String, CallbackQueryHandler>>? actions])
-      : actions = actions ?? [{}],
-        inlineKeyboard = _make(actions);
+  InlineMenu({
+    List<Map<String, CallbackQueryHandler>>? actions,
+    this.name,
+  })  : actions = actions ?? [{}],
+        inlineKeyboard = TeleverseMenu._makeInlineKeyboard(actions);
 
   /// Add a new row to the keyboard
   InlineMenu row() {
     if (actions.last.isEmpty) return this;
     actions.add({});
-    inlineKeyboard = _make(actions);
+    inlineKeyboard = TeleverseMenu._makeInlineKeyboard(actions);
     return this;
   }
 
   /// Add new item to the last row
   InlineMenu text(String text, CallbackQueryHandler handler) {
     if (actions.isEmpty) actions.add({});
-    actions.last.addAll({
-      text: handler,
-    });
-    inlineKeyboard = _make(actions);
+    actions.last.addAll({text: handler});
+    inlineKeyboard = TeleverseMenu._makeInlineKeyboard(actions);
     return this;
   }
 
+  /// List of rows of the keyboard
   @override
   List<List<InlineKeyboardButton>> inlineKeyboard;
 
+  /// Converts the object to a JSON object
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -40,16 +50,5 @@ class InlineMenu implements InlineKeyboardMarkup {
         }).toList();
       }).toList(),
     }..removeWhere((key, value) => value == null);
-  }
-
-  static List<List<InlineKeyboardButton>> _make(
-    List<Map<String, CallbackQueryHandler>>? rows,
-  ) {
-    if (rows == null) return [];
-    return rows.map((row) {
-      return row.keys.map((element) {
-        return InlineKeyboardButton(text: element, callbackData: element);
-      }).toList();
-    }).toList();
   }
 }

--- a/lib/src/televerse/markups/inline_menu.dart
+++ b/lib/src/televerse/markups/inline_menu.dart
@@ -7,7 +7,7 @@ class InlineMenu
         TeleverseMenu<CallbackQueryContext, CallbackQueryHandler> {
   /// Name of the menu
   @override
-  String? name;
+  String name;
 
   /// Map that represents the text and action to be done
   @override
@@ -16,9 +16,10 @@ class InlineMenu
   /// Constructs a InlineMenu
   InlineMenu({
     List<Map<String, CallbackQueryHandler>>? actions,
-    this.name,
+    String? name,
   })  : actions = actions ?? [{}],
-        inlineKeyboard = TeleverseMenu._makeInlineKeyboard(actions);
+        inlineKeyboard = TeleverseMenu._makeInlineKeyboard(actions),
+        name = name ?? _getRandomID();
 
   /// Add a new row to the keyboard
   InlineMenu row() {

--- a/lib/src/televerse/markups/keyboard_menu.dart
+++ b/lib/src/televerse/markups/keyboard_menu.dart
@@ -1,0 +1,186 @@
+part of televerse;
+
+/// This object represents a Keyboard menu with the actions to be done.
+class KeyboardMenu
+    implements
+        ReplyKeyboardMarkup,
+        TeleverseMenu<MessageContext, MessageHandler> {
+  /// Name of the menu
+  @override
+  String name;
+
+  /// Map that represents the text and action to be done
+  @override
+  List<Map<String, MessageHandler>> actions;
+
+  /// Constructs a KeyboardMenu
+  KeyboardMenu({
+    String? name,
+    this.inputFieldPlaceholder,
+    this.isPersistent,
+    this.oneTimeKeyboard,
+    this.resizeKeyboard,
+    this.selective,
+  })  : actions = [{}],
+        keyboard = [[]],
+        name = name ?? _getRandomID();
+
+  /// Add a new row to the keyboard
+  KeyboardMenu row() {
+    if (actions.last.isEmpty) return this;
+    actions.add({});
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// Add new item to the last row
+  KeyboardMenu text(String text, MessageHandler handler) {
+    if (actions.isEmpty) actions.add({});
+    final data = jsonEncode({'type': 'text', 'text': text});
+    actions.last.addAll({data: handler});
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// Request contact from the user
+  KeyboardMenu requestContact(String text, MessageHandler handler) {
+    if (actions.isEmpty) actions.add({});
+    String data = jsonEncode({'type': 'request_contact', 'text': text});
+    actions.last.addAll({data: handler});
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// Request location from the user
+  KeyboardMenu requestLocation(String text, MessageHandler handler) {
+    if (actions.isEmpty) actions.add({});
+    String data = jsonEncode({'type': 'request_location', 'text': text});
+    actions.last.addAll({data: handler});
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// Request the user to select a user from the list
+  KeyboardMenu requestUser({
+    required String text,
+    required MessageHandler handler,
+    required int requestId,
+    bool? isBot,
+    bool? userIsPremium,
+  }) {
+    final data = jsonEncode({
+      'type': 'request_user',
+      'text': text,
+      'request_id': requestId,
+      'is_bot': isBot,
+      'user_is_premium': userIsPremium,
+    });
+    if (actions.isEmpty) actions.add({});
+    actions.last.addAll({
+      data: handler,
+    });
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// Requests the user to select a chat from the list.
+  KeyboardMenu requestChat({
+    required String text,
+    required MessageHandler handler,
+    required int requestId,
+    bool chatIsChannel = false,
+    bool? chatIsForum,
+    bool? chatHasUsername,
+    bool? chatIsCreated,
+    ChatAdministratorRights? userAdministratorRights,
+    ChatAdministratorRights? botAdministratorRights,
+    bool? botIsMember,
+  }) {
+    final data = jsonEncode({
+      'type': 'request_chat',
+      'text': text,
+      'request_id': requestId,
+      'chat_is_channel': chatIsChannel,
+      'chat_is_forum': chatIsForum,
+      'chat_has_username': chatHasUsername,
+      'chat_is_created': chatIsCreated,
+      'user_administrator_rights': userAdministratorRights?.toJson(),
+      'bot_administrator_rights': botAdministratorRights?.toJson(),
+      'bot_is_member': botIsMember,
+    });
+    if (actions.isEmpty) actions.add({});
+    actions.last.addAll({
+      data: handler,
+    });
+    keyboard = TeleverseMenu._makeKeyboard(actions);
+    return this;
+  }
+
+  /// List of rows of the keyboard
+  @override
+  List<List<KeyboardButton>> keyboard;
+
+  /// Converts the object to a JSON object
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'keyboard': keyboard.map((row) {
+        return row.map((button) {
+          return button.toJson();
+        }).toList();
+      }).toList(),
+      'input_field_placeholder': inputFieldPlaceholder,
+      'is_persistent': isPersistent,
+      'one_time_keyboard': oneTimeKeyboard,
+      'resize_keyboard': resizeKeyboard,
+      'selective': selective,
+    }..removeWhere((key, value) => value == null);
+  }
+
+  /// Optional. The placeholder to be shown in the input field when the keyboard is active; 1-64 characters
+  @override
+  String? inputFieldPlaceholder;
+
+  /// Optional. Requests clients to always show the keyboard when the regular keyboard is hidden. Defaults to false, in which case the custom keyboard can be hidden and opened with a keyboard icon.
+  @override
+  bool? isPersistent;
+
+  /// Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false.
+  @override
+  bool? oneTimeKeyboard;
+
+  /// Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.
+  @override
+  bool? resizeKeyboard;
+
+  /// Optional. Use this parameter if you want to show the keyboard to specific users only.
+  /// Targets:
+  ///   1) users that are @mentioned in the text of the [Message] object;
+  ///   2) if the bot's message is a reply (has [Message.replyToMessage]), sender of the original message.Example: A user requests to change the bot‘s language, bot replies to the request with a keyboard to select the new language. Other users in the group don’t see the keyboard.
+  @override
+  bool? selective;
+
+  /// Makes the menu resized
+  KeyboardMenu resized() {
+    resizeKeyboard = true;
+    return this;
+  }
+
+  /// Makes the menu persistent
+  KeyboardMenu persistent() {
+    isPersistent = true;
+    return this;
+  }
+
+  /// Makes the menu one time
+  KeyboardMenu oneTime() {
+    oneTimeKeyboard = true;
+    return this;
+  }
+
+  /// Makes the menu selective
+  KeyboardMenu makeSelective() {
+    selective = true;
+    return this;
+  }
+}

--- a/lib/src/televerse/markups/menu.dart
+++ b/lib/src/televerse/markups/menu.dart
@@ -1,0 +1,44 @@
+part of televerse;
+
+/// Abstract class to represent a menu
+abstract class TeleverseMenu<CTX extends Context,
+    CtxHandler extends FutureOr<void> Function(CTX)> {
+  /// Map that represents the text and action to be done
+  List<Map<String, CtxHandler>> actions;
+
+  /// Name of the menu
+  String? name;
+
+  /// Converts the object to a JSON object
+  Map<String, dynamic> toJson();
+
+  /// Converts a list of rows to a list of InlineKeyboardButton
+  static List<List<InlineKeyboardButton>> _makeInlineKeyboard(
+    List<Map<String, CallbackQueryHandler>>? rows,
+  ) {
+    if (rows == null) return [];
+    return rows.map((row) {
+      return row.keys.map((element) {
+        return InlineKeyboardButton(text: element, callbackData: element);
+      }).toList();
+    }).toList();
+  }
+
+  /// Converts a list of rows to a list of KeyboardButton
+  static List<List<KeyboardButton>> _makeKeyboard(
+    List<Map<String, MessageHandler>>? rows,
+  ) {
+    if (rows == null) return [];
+    return rows.map((row) {
+      return row.keys.map((element) {
+        return KeyboardButton(text: element);
+      }).toList();
+    }).toList();
+  }
+
+  /// Constructs a TeleverseMenu
+  TeleverseMenu({
+    List<Map<String, CtxHandler>>? actions,
+    this.name,
+  }) : actions = actions ?? [{}];
+}

--- a/lib/src/televerse/markups/menu.dart
+++ b/lib/src/televerse/markups/menu.dart
@@ -7,7 +7,7 @@ abstract class TeleverseMenu<CTX extends Context,
   List<Map<String, CtxHandler>> actions;
 
   /// Name of the menu
-  String? name;
+  String name;
 
   /// Converts the object to a JSON object
   Map<String, dynamic> toJson();
@@ -30,8 +30,36 @@ abstract class TeleverseMenu<CTX extends Context,
   ) {
     if (rows == null) return [];
     return rows.map((row) {
-      return row.keys.map((element) {
-        return KeyboardButton(text: element);
+      return row.keys.map((e) {
+        final data = jsonDecode(e);
+        final text = data['text'];
+        final type = data['type'];
+        switch (type) {
+          case 'text':
+            return KeyboardButton(text: text);
+          case 'request_contact':
+            return KeyboardButton(
+              text: text,
+              requestContact: true,
+            );
+          case 'request_location':
+            return KeyboardButton(
+              text: text,
+              requestLocation: true,
+            );
+          case 'request_user':
+            return KeyboardButton(
+              text: text,
+              requestUser: KeyboardButtonRequestUser.fromJson(data),
+            );
+          case 'request_chat':
+            return KeyboardButton(
+              text: text,
+              requestChat: KeyboardButtonRequestChat.fromJson(data),
+            );
+          default:
+            return KeyboardButton(text: text);
+        }
       }).toList();
     }).toList();
   }
@@ -39,6 +67,7 @@ abstract class TeleverseMenu<CTX extends Context,
   /// Constructs a TeleverseMenu
   TeleverseMenu({
     List<Map<String, CtxHandler>>? actions,
-    this.name,
-  }) : actions = actions ?? [{}];
+    String? name,
+  })  : actions = actions ?? [{}],
+        name = name ?? _getRandomID();
 }

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -1795,4 +1795,22 @@ class Televerse<TeleverseSession extends Session> {
       onlyChannelPosts: onlyChannelPosts,
     );
   }
+
+  /// Attach an Inline Menu.
+  ///
+  /// This method will make the menu handlers to be called when the menu buttons are pressed.
+  void attachMenu(InlineMenu menu) {
+    int rows = menu.actions.length;
+    for (int i = 0; i < rows; i++) {
+      int cols = menu.actions[i].length;
+      for (int j = 0; j < cols; j++) {
+        final key = menu.actions[i].keys.elementAt(j);
+        final action = menu.actions[i][key]!;
+        callbackQuery(
+          key,
+          action,
+        );
+      }
+    }
+  }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -11,3 +11,13 @@ extension CleanString on String {
   /// Typesafe for args, replace all white space or multiple space in [String] into single space
   String get clean => trim().replaceAll(RegExp(r'\s{2,}|[\t\r\n]'), ' ');
 }
+
+/// Internal method to generate a random id.
+/// Include a-z, A-Z, 0-9
+String _getRandomID() {
+  final random = Random();
+  final chars =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  return List.generate(20, (index) => chars[random.nextInt(chars.length)])
+      .join();
+}

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -46,6 +46,7 @@ part 'src/televerse/raw_api.dart';
 part 'src/televerse/sessions/sessions.dart';
 part 'src/televerse/filters/on.dart';
 part 'src/televerse/filters/filters.dart';
+part 'src/televerse/markups/inline_menu.dart';
 
 /// Conversation API
 part 'src/conversation/conversation.dart';

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -48,6 +48,7 @@ part 'src/televerse/filters/on.dart';
 part 'src/televerse/filters/filters.dart';
 part 'src/televerse/markups/inline_menu.dart';
 part 'src/televerse/markups/menu.dart';
+part 'src/televerse/markups/keyboard_menu.dart';
 
 /// Conversation API
 part 'src/conversation/conversation.dart';

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -47,6 +47,7 @@ part 'src/televerse/sessions/sessions.dart';
 part 'src/televerse/filters/on.dart';
 part 'src/televerse/filters/filters.dart';
 part 'src/televerse/markups/inline_menu.dart';
+part 'src/televerse/markups/menu.dart';
 
 /// Conversation API
 part 'src/conversation/conversation.dart';


### PR DESCRIPTION
The TeleverseMenu is a markup assist to create InlineKeyboards or Keyboards in an easy and efficient way.

For example, there will be many times you will have to show an Inline Keyboard to the user. And for all the callback queries received you might want to set up a handler by repeatedly using the `bot.callbackQuery` or a totally messy code with `bot.onCallbackQuery`.

Here comes Menus to rescue. The following is a simple example to illustrate its usage.

```dart
// Create the menu
final startMenu = InlineMenu(name: "Start Menu")
    .text("Hello", helloCallback)
    .row()
    .text("Start", firstCallback)
    .text("Finish", finishCallback);
```


And then we simply attach the menu to the bot and the bot will start listening for menu updates.

```dart
  // Attach it to the bot
  bot.attachMenu(startMenu);
```


 After that, we'll show the menu to the user just like we show a Keyboard or InlineKeyboard.

```dart
 // Start the bot and listen for /start command updates
  bot.start((ctx) {
    // Reply with the menu
    ctx.reply(
      "Hello, choose an option:",
      replyMarkup: startMenu,
    );
  });
```

There we go, isn't that simple? 😉