### PR TITLE
Fix/provider data type dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+/.idea/libraries/Dart_Packages.xml
+/.idea/libraries/Dart_SDK.xml
+/.idea/.gitignore
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/televerse.iml
+/.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,6 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
-/.idea/libraries/Dart_Packages.xml
-/.idea/libraries/Dart_SDK.xml
-/.idea/.gitignore
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/televerse.iml
-/.idea/vcs.xml
+
+# IntelliJ IDEA files.
+/.idea/*

--- a/lib/src/telegram/models.dart
+++ b/lib/src/telegram/models.dart
@@ -4571,16 +4571,16 @@ class MessageAutoDeleteTimerChanged {
 /// This object represents information about an order.
 class OrderInfo {
   /// User name
-  String name;
+  String? name;
 
   /// User's phone number
-  String phoneNumber;
+  String? phoneNumber;
 
   /// User email
-  String email;
+  String? email;
 
   /// User shipping address
-  ShippingAddress shippingAddress;
+  ShippingAddress? shippingAddress;
 
   /// Creates a new [OrderInfo] object.
   OrderInfo({
@@ -4596,17 +4596,19 @@ class OrderInfo {
       'name': name,
       'phone_number': phoneNumber,
       'email': email,
-      'shipping_address': shippingAddress.toJson(),
+      'shipping_address': shippingAddress?.toJson(),
     }..removeWhere((key, value) => value == null);
   }
 
   /// Creates a [OrderInfo] object from a JSON object
   factory OrderInfo.fromJson(Map<String, dynamic> json) {
     return OrderInfo(
-      name: json['name']!,
-      phoneNumber: json['phone_number']!,
-      email: json['email']!,
-      shippingAddress: ShippingAddress.fromJson(json['shipping_address']!),
+      name: json['name'],
+      phoneNumber: json['phone_number'],
+      email: json['email'],
+      shippingAddress: json['shipping_address'] != null
+          ? ShippingAddress.fromJson(json['shipping_address'])
+          : null,
     );
   }
 }

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -2701,7 +2701,7 @@ class RawAPI {
     int? maxTipAmount = 0,
     List<int>? suggestedTipAmounts,
     String? startParameter,
-    String? providerData,
+    dynamic providerData,
     String? photoUrl,
     int? photoSize,
     int? photoWidth,


### PR DESCRIPTION
Fixes for purchase flow models
- Change providerData type to dynamic
- Make `OrderInfo` fields nullable as by documentation https://core.telegram.org/bots/api#orderinfo