### PR TITLE
Bot API 7.0 - Other Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,16 @@
 - Added the class `UsersShared`.
 - Replaced the field `user_shared` in the class Message with the field `users_shared`.
 
-# Chat Boosts 🚀
+## Chat Boosts 🚀
 
 - 🆕 New methods to listen the `ChatBoostUpdated` and `ChatBoostRemoved` updates, respectively `Televerse.onChatBoosted`, `Televerse.onChatBoostRemoved` are added.
 - 🆕 New context objects `ChatBoostUpdatedContext` and `ChatBoostRemovedContext` are added.
+
+## Other Changes 🎉
+
+- Updated `Chat` model to reflect the changes in the API.
+- ⚠️ BREAKING: Added the class `MessageOrigin` and replaced the fields `forward_from`, `forward_from_chat`, `forward_from_message_id`, `forward_signature`, `forward_sender_name`, and `forward_date` with the field `forwardOrigin` of type `MessageOrigin` in the class `Message`.
+- ⚠️ BREAKING: `CallbackQuery.message` is now of the type `MaybeInaccessibleMessage` instead of `Message`.
 
 # 1.11.5
 

--- a/lib/src/telegram/models/abstracts/maybe_inaccessible_message.dart
+++ b/lib/src/telegram/models/abstracts/maybe_inaccessible_message.dart
@@ -1,0 +1,47 @@
+part of '../models.dart';
+
+/// This object describes a message that can be inaccessible to the bot. It can be one of
+/// - [Message]
+/// - [InaccessibleMessage]
+abstract class MaybeInaccessibleMessage {
+  /// Chat the message belonged to
+  final Chat chat;
+
+  /// Unique message identifier inside the chat
+  final int messageId;
+
+  /// Always 0. The field can be used to differentiate regular and inaccessible messages.
+  final int date;
+
+  /// Constructor
+  const MaybeInaccessibleMessage({
+    required this.chat,
+    required this.messageId,
+    required this.date,
+  });
+
+  /// Constructor from JSON data
+  factory MaybeInaccessibleMessage.fromJson(Map<String, dynamic> json) {
+    final hasOnlyThreeProps = json.keys.length == 3;
+    if (hasOnlyThreeProps) {
+      return InaccessibleMessage.fromJson(json);
+    } else {
+      return Message.fromJson(json);
+    }
+  }
+
+  /// Converts to JSON encodable [Map]
+  Map<String, dynamic> toJson() {
+    return {
+      'chat': chat.toJson(),
+      'message_id': messageId,
+      'date': date,
+    };
+  }
+
+  /// Returns `true` if this message is accessible.
+  bool get isAccessible => this is Message;
+
+  /// Returns `true` if this message is inaccessible.
+  bool get isInaccessible => this is InaccessibleMessage;
+}

--- a/lib/src/telegram/models/abstracts/message_origin.dart
+++ b/lib/src/telegram/models/abstracts/message_origin.dart
@@ -1,14 +1,23 @@
 part of '../models.dart';
 
 /// This object describes the origin of a message. It can be one of
-/// - MessageOriginUser
-/// - MessageOriginHiddenUser
-/// - MessageOriginChat
-/// - MessageOriginChannel
+/// - [MessageOriginUser]
+/// - [MessageOriginHiddenUser]
+/// - [MessageOriginChat]
+/// - [MessageOriginChannel]
 
 abstract class MessageOrigin {
+  /// Type of the message origin
+  final MessageOriginType type;
+
+  /// Date the message was sent originally in Unix time
+  final int date;
+
   /// Creates a new [MessageOrigin] instance.
-  MessageOrigin();
+  MessageOrigin({
+    required this.type,
+    required this.date,
+  });
 
   /// Creates a new [MessageOrigin] instance from a JSON object.
   factory MessageOrigin.fromJson(Map<String, dynamic> json) {

--- a/lib/src/telegram/models/callback_query.dart
+++ b/lib/src/telegram/models/callback_query.dart
@@ -5,28 +5,28 @@ part of 'models.dart';
 /// NOTE: After the user presses a callback button, Telegram clients will display a progress bar until you call [answerCallbackQuery](https://core.telegram.org/bots/api#answercallbackquery). It is, therefore, necessary to react by calling [answerCallbackQuery](https://core.telegram.org/bots/api#answercallbackquery) even if no notification to the user is needed (e.g., without specifying any of the optional parameters).
 class CallbackQuery {
   /// Unique identifier for this query
-  String id;
+  final String id;
 
   /// Sender
-  User user;
+  final User user;
 
-  /// Optional. Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old
-  Message? message;
+  /// Optional. Message sent by the bot with the callback button that originated the query
+  final MaybeInaccessibleMessage? message;
 
   /// Optional. Identifier of the message sent via the bot in inline mode, that originated the query.
-  String? inlineMessageId;
+  final String? inlineMessageId;
 
   /// Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games.
-  String chatInstance;
+  final String chatInstance;
 
   /// Optional. Data associated with the callback button. Be aware that the message originated the query can contain no callback buttons with this data.
-  String? data;
+  final String? data;
 
   /// Optional. Short name of a Game to be returned, serves as the unique identifier for the game
-  String? gameShortName;
+  final String? gameShortName;
 
   /// Creates a new CallbackQuery object.
-  CallbackQuery({
+  const CallbackQuery({
     required this.id,
     required this.user,
     this.message,

--- a/lib/src/telegram/models/chat.dart
+++ b/lib/src/telegram/models/chat.dart
@@ -29,9 +29,6 @@ class Chat {
   /// Optional. If non-empty, the list of all active chat usernames; for private chats, supergroups and channels. Returned only in getChat.
   final List<String>? activeUsernames;
 
-  /// Optional. Custom emoji identifier of emoji status of the other party in a private chat. Returned only in getChat.
-  final String? emojiStatusSustomEmojiId;
-
   /// Optional. Bio of the other party in a private chat. Returned only in getChat.
   final String? bio;
 
@@ -89,8 +86,26 @@ class Chat {
   /// Optional. Expiration date of the emoji status of the other party in a private chat, if any. Returned only in getChat.
   final int? emojiStatusExpirationDate;
 
-  /// Optional. List of available reactions allowed in the chat. If omitted, then all emoji reactions are allowed. Returned only in getChat.
+  /// Optional. Expiration date of the emoji status of the chat or the other party in a private chat, in Unix time, if any. Returned only in getChat.
   final List<ReactionType>? availableReactions;
+
+  /// Optional. Custom emoji identifier of the emoji status of the chat or the other party in a private chat. Returned only in getChat.
+  final String? emojiStatusCustomEmojiId;
+
+  /// Optional. Identifier of the accent color for the chat name and backgrounds of the chat photo, reply header, and link preview. See [accent colors](https://core.telegram.org/bots/api#accent-colors) for more details. Returned only in getChat. Always returned in [getChat](https://core.telegram.org/bots/api#getchat)
+  final int? accentColorId;
+
+  /// Optional. Custom emoji identifier of emoji chosen by the chat for the reply header and link preview background. Returned only in getChat.
+  final String? backgroundCustomEmojiId;
+
+  /// Optional. Identifier of the accent color for the chat's profile background. See profile accent colors for more details. Returned only in getChat.
+  final int? profileAccentColorId;
+
+  /// Optional. Custom emoji identifier of the emoji chosen by the chat for its profile background. Returned only in getChat.
+  final String? profileBackgroundCustomEmojiId;
+
+  /// Optional. True, if new chat members will have access to old messages; available only to chat administrators. Returned only in getChat.
+  final bool? hasVisibleHistory;
 
   /// Constructs a [Chat] object.
   const Chat({
@@ -103,7 +118,6 @@ class Chat {
     this.isForum,
     this.photo,
     this.activeUsernames,
-    this.emojiStatusSustomEmojiId,
     this.bio,
     this.hasPrivateForwards,
     this.hasRestrictedVoiceAndVideoMessages,
@@ -124,6 +138,12 @@ class Chat {
     this.hasAggressiveAntiSpamEnabled,
     this.emojiStatusExpirationDate,
     this.availableReactions,
+    this.emojiStatusCustomEmojiId,
+    this.accentColorId,
+    this.backgroundCustomEmojiId,
+    this.profileAccentColorId,
+    this.profileBackgroundCustomEmojiId,
+    this.hasVisibleHistory,
   });
 
   /// Creates a [Chat] object from json.
@@ -140,7 +160,6 @@ class Chat {
       activeUsernames: (json['active_usernames'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
-      emojiStatusSustomEmojiId: json['emoji_status_custom_emoji_id'],
       bio: json['bio'],
       hasPrivateForwards: json['has_private_forwards'],
       hasRestrictedVoiceAndVideoMessages:
@@ -170,6 +189,13 @@ class Chat {
       availableReactions: (json['available_reactions'] as List<dynamic>?)
           ?.map((e) => ReactionType.fromJson(e))
           .toList(),
+      emojiStatusCustomEmojiId: json['emoji_status_custom_emoji_id'],
+      accentColorId: json['accent_color_id'],
+      backgroundCustomEmojiId: json['background_custom_emoji_id'],
+      profileAccentColorId: json['profile_accent_color_id'],
+      profileBackgroundCustomEmojiId:
+          json['profile_background_custom_emoji_id'],
+      hasVisibleHistory: json['has_visible_history'],
     );
   }
 
@@ -185,7 +211,6 @@ class Chat {
       'is_forum': isForum,
       'photo': photo?.toJson(),
       'active_usernames': activeUsernames,
-      'emoji_status_custom_emoji_id': emojiStatusSustomEmojiId,
       'bio': bio,
       'has_private_forwards': hasPrivateForwards,
       'has_restricted_voice_and_video_messages':
@@ -208,6 +233,12 @@ class Chat {
       'emoji_status_expiration_date': emojiStatusExpirationDate,
       'available_reactions':
           availableReactions?.map((e) => e.toJson()).toList(),
+      'emoji_status_custom_emoji_id': emojiStatusCustomEmojiId,
+      'accent_color_id': accentColorId,
+      'background_custom_emoji_id': backgroundCustomEmojiId,
+      'profile_accent_color_id': profileAccentColorId,
+      'profile_background_custom_emoji_id': profileBackgroundCustomEmojiId,
+      'has_visible_history': hasVisibleHistory,
     }..removeWhere((key, value) => value == null);
   }
 }

--- a/lib/src/telegram/models/inaccessible_message.dart
+++ b/lib/src/telegram/models/inaccessible_message.dart
@@ -1,0 +1,30 @@
+part of 'models.dart';
+
+/// This object describes a message that was deleted or is otherwise inaccessible to the bot.
+class InaccessibleMessage extends MaybeInaccessibleMessage {
+  /// Constructor
+  const InaccessibleMessage({
+    required super.chat,
+    required super.messageId,
+    required super.date,
+  });
+
+  /// Constructor from JSON data
+  factory InaccessibleMessage.fromJson(Map<String, dynamic> json) {
+    return InaccessibleMessage(
+      chat: Chat.fromJson(json['chat']),
+      messageId: json['message_id'],
+      date: json['date'],
+    );
+  }
+
+  /// Converts to JSON encodable [Map]
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'chat': chat.toJson(),
+      'message_id': messageId,
+      'date': date,
+    };
+  }
+}

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -1,10 +1,7 @@
 part of 'models.dart';
 
 /// This object represents a message.
-class Message {
-  /// Unique message identifier inside this chat
-  final int messageId;
-
+class Message extends MaybeInaccessibleMessage {
   /// Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
   final int? messageThreadId;
 
@@ -13,14 +10,6 @@ class Message {
 
   /// Optional. Sender of the message, sent on behalf of a chat. For example, the channel itself for channel posts, the supergroup itself for messages from anonymous group administrators, the linked channel for messages automatically forwarded to the discussion group. For backward compatibility, the field from contains a fake sender user in non-channel chats, if the message was sent on behalf of a chat.
   final Chat? senderChat;
-
-  /// Date the message was sent in Unix time
-  ///
-  /// Note: Handy [DateTime] object is available in [dateTime] getter.
-  final int date;
-
-  /// Conversation the message belongs to
-  final Chat chat;
 
   /// Optional. Information about the original message for forwarded messages
   final MessageOrigin? forwardOrigin;
@@ -230,11 +219,11 @@ class Message {
 
   /// Creates a Message object.
   const Message({
-    required this.messageId,
+    required super.messageId,
     this.from,
     this.senderChat,
-    required this.date,
-    required this.chat,
+    required super.date,
+    required super.chat,
     this.replyToMessage,
     this.viaBot,
     this.editDate,
@@ -475,6 +464,7 @@ class Message {
   }
 
   /// Returns the JSON representation of the Message object.
+  @override
   Map<String, dynamic> toJson() {
     return {
       'message_id': messageId,

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -22,25 +22,8 @@ class Message {
   /// Conversation the message belongs to
   final Chat chat;
 
-  /// Optional. For forwarded messages, sender of the original message
-  final User? forwardFrom;
-
-  /// Optional. For messages forwarded from channels or from anonymous administrators, information about the original sender chat
-  final Chat? forwardFromChat;
-
-  /// Optional. For messages forwarded from channels, identifier of the original message in the channel
-  final int? forwardFromMessageId;
-
-  /// Optional. For forwarded messages that were originally sent in channels or by an anonymous chat administrator, signature of the message sender if present
-  final String? forwardSignature;
-
-  /// Optional. Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages
-  final String? forwardSenderName;
-
-  /// Optional. For forwarded messages, date the original message was sent in Unix time
-  ///
-  /// Note: Handy [DateTime] object is available in [forwardDateTime] getter.
-  final int? forwardDate;
+  /// Optional. Information about the original message for forwarded messages
+  final MessageOrigin? forwardOrigin;
 
   /// Optional. True, if the message is sent to a forum topic
   final bool? isTopicMessage;
@@ -252,12 +235,6 @@ class Message {
     this.senderChat,
     required this.date,
     required this.chat,
-    this.forwardFrom,
-    this.forwardFromChat,
-    this.forwardFromMessageId,
-    this.forwardSignature,
-    this.forwardSenderName,
-    this.forwardDate,
     this.replyToMessage,
     this.viaBot,
     this.editDate,
@@ -326,6 +303,7 @@ class Message {
     this.giveawayCreated,
     this.giveawayWinners,
     this.giveawayCompleted,
+    this.forwardOrigin,
   });
 
   /// Creates a [Message] object from json map.
@@ -338,16 +316,6 @@ class Message {
           : Chat.fromJson(json['sender_chat']),
       date: json['date'],
       chat: Chat.fromJson(json['chat']),
-      forwardFrom: json['forward_from'] == null
-          ? null
-          : User.fromJson(json['forward_from']),
-      forwardFromChat: json['forward_from_chat'] == null
-          ? null
-          : Chat.fromJson(json['forward_from_chat']),
-      forwardFromMessageId: json['forward_from_message_id'],
-      forwardSignature: json['forward_signature'],
-      forwardSenderName: json['forward_sender_name'],
-      forwardDate: json['forward_date'],
       replyToMessage: json['reply_to_message'] == null
           ? null
           : Message.fromJson(json['reply_to_message']),
@@ -500,6 +468,9 @@ class Message {
       giveawayCompleted: json['giveaway_completed'] == null
           ? null
           : GiveawayCompleted.fromJson(json['giveaway_completed']),
+      forwardOrigin: json['forward_origin'] == null
+          ? null
+          : MessageOrigin.fromJson(json['forward_origin']),
     );
   }
 
@@ -511,12 +482,6 @@ class Message {
       'sender_chat': senderChat?.toJson(),
       'date': date,
       'chat': chat.toJson(),
-      'forward_from': forwardFrom?.toJson(),
-      'forward_from_chat': forwardFromChat?.toJson(),
-      'forward_from_message_id': forwardFromMessageId,
-      'forward_signature': forwardSignature,
-      'forward_sender_name': forwardSenderName,
-      'forward_date': forwardDate,
       'reply_to_message': replyToMessage?.toJson(),
       'via_bot': viaBot?.toJson(),
       'edit_date': editDate,
@@ -586,6 +551,7 @@ class Message {
       'giveaway_created': giveawayCreated?.toJson(),
       'giveaway_winners': giveawayWinners?.toJson(),
       'giveaway_completed': giveawayCompleted?.toJson(),
+      'forward_origin': forwardOrigin?.toJson(),
     }..removeWhere((key, value) => value == null);
   }
 
@@ -598,9 +564,10 @@ class Message {
       : DateTime.fromMillisecondsSinceEpoch(editDate! * 1000);
 
   /// Getter for the [DateTime] object that represents the message forward date
-  DateTime? get forwardDateTime => forwardDate == null
-      ? null
-      : DateTime.fromMillisecondsSinceEpoch(forwardDate! * 1000);
+  DateTime? get forwardDateTime {
+    if (forwardOrigin == null) return null;
+    return DateTime.fromMillisecondsSinceEpoch(forwardOrigin!.date * 1000);
+  }
 
   /// Returns true if the message is a command
   bool get isCommand => entities != null && entities!.isNotEmpty

--- a/lib/src/telegram/models/message_origin_channel.dart
+++ b/lib/src/telegram/models/message_origin_channel.dart
@@ -1,0 +1,51 @@
+part of 'models.dart';
+
+/// This object represents a message that was originally sent to a channel chat.
+class MessageOriginChannel implements MessageOrigin {
+  /// Type of the message origin, always “channel”
+  @override
+  final MessageOriginType type = MessageOriginType.channel;
+
+  /// Date the message was sent originally in Unix time
+  @override
+  final int date;
+
+  /// Channel chat to which the message was originally sent
+  final Chat chat;
+
+  /// Unique message identifier inside the chat
+  final int messageId;
+
+  /// Signature of the original post author
+  final String? authorSignature;
+
+  /// Constructor
+  MessageOriginChannel({
+    required this.date,
+    required this.chat,
+    required this.messageId,
+    this.authorSignature,
+  });
+
+  /// Constructor from JSON data
+  factory MessageOriginChannel.fromJson(Map<String, dynamic> json) {
+    return MessageOriginChannel(
+      date: json['date'],
+      chat: Chat.fromJson(json['chat']),
+      messageId: json['message_id'],
+      authorSignature: json['author_signature'],
+    );
+  }
+
+  /// Converts to JSON encodable [Map]
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type.value,
+      'date': date,
+      'chat': chat.toJson(),
+      'message_id': messageId,
+      'author_signature': authorSignature,
+    }..removeWhere((_, v) => v == null);
+  }
+}

--- a/lib/src/telegram/models/message_origin_chat.dart
+++ b/lib/src/telegram/models/message_origin_chat.dart
@@ -1,0 +1,45 @@
+part of 'models.dart';
+
+/// This object represents a message that was originally sent on behalf of a chat to a group chat.
+class MessageOriginChat implements MessageOrigin {
+  /// Type of the message origin, always “chat”
+  @override
+  final MessageOriginType type = MessageOriginType.chat;
+
+  /// Date the message was sent originally in Unix time
+  @override
+  final int date;
+
+  /// Chat that sent the message originally
+  final Chat senderChat;
+
+  /// For messages originally sent by an anonymous chat administrator, original message author signature
+  final String? authorSignature;
+
+  /// Constructor
+  MessageOriginChat({
+    required this.date,
+    required this.senderChat,
+    this.authorSignature,
+  });
+
+  /// Constructor from JSON data
+  factory MessageOriginChat.fromJson(Map<String, dynamic> json) {
+    return MessageOriginChat(
+      date: json['date'],
+      senderChat: Chat.fromJson(json['sender_chat']),
+      authorSignature: json['author_signature'],
+    );
+  }
+
+  /// Converts to JSON encodable [Map]
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type.value,
+      'date': date,
+      'sender_chat': senderChat.toJson(),
+      'author_signature': authorSignature,
+    }..removeWhere((_, v) => v == null);
+  }
+}

--- a/lib/src/telegram/models/message_origin_hidden_user.dart
+++ b/lib/src/telegram/models/message_origin_hidden_user.dart
@@ -1,0 +1,39 @@
+part of 'models.dart';
+
+/// This object represents a message that was originally sent by an unknown user.
+class MessageOriginHiddenUser implements MessageOrigin {
+  /// Type of the message origin, always “hidden_user”
+  @override
+  final MessageOriginType type = MessageOriginType.hiddenUser;
+
+  /// Date the message was sent originally in Unix time
+  @override
+  final int date;
+
+  /// Name of the user that sent the message originally
+  final String senderUserName;
+
+  /// Constructor
+  MessageOriginHiddenUser({
+    required this.date,
+    required this.senderUserName,
+  });
+
+  /// Constructor from JSON data
+  factory MessageOriginHiddenUser.fromJson(Map<String, dynamic> json) {
+    return MessageOriginHiddenUser(
+      date: json['date'],
+      senderUserName: json['sender_user_name'],
+    );
+  }
+
+  /// Converts to JSON encodable [Map]
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type.value,
+      'date': date,
+      'sender_user_name': senderUserName,
+    };
+  }
+}

--- a/lib/src/telegram/models/message_origin_user.dart
+++ b/lib/src/telegram/models/message_origin_user.dart
@@ -1,0 +1,39 @@
+part of 'models.dart';
+
+/// This object represents a message that was originally sent by a known user.
+class MessageOriginUser implements MessageOrigin {
+  /// Type of the message origin, always “user”
+  @override
+  final MessageOriginType type = MessageOriginType.user;
+
+  /// Date the message was sent originally in Unix time
+  @override
+  final int date;
+
+  /// User that sent the message originally
+  final User senderUser;
+
+  /// Constructor
+  MessageOriginUser({
+    required this.date,
+    required this.senderUser,
+  });
+
+  /// Constructor from JSON data
+  factory MessageOriginUser.fromJson(Map<String, dynamic> json) {
+    return MessageOriginUser(
+      date: json['date'],
+      senderUser: User.fromJson(json['sender_user']),
+    );
+  }
+
+  /// Converts to JSON encodable [Map]
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type.value,
+      'date': date,
+      'sender_user': senderUser.toJson(),
+    };
+  }
+}

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -179,3 +179,7 @@ part 'chat_boost_removed.dart';
 part 'user_chat_boosts.dart';
 part 'giveaway_created.dart';
 part 'giveaway_completed.dart';
+part 'message_origin_user.dart';
+part 'message_origin_hidden_user.dart';
+part 'message_origin_chat.dart';
+part 'message_origin_channel.dart';

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -183,3 +183,5 @@ part 'message_origin_user.dart';
 part 'message_origin_hidden_user.dart';
 part 'message_origin_chat.dart';
 part 'message_origin_channel.dart';
+part 'abstracts/maybe_inaccessible_message.dart';
+part 'inaccessible_message.dart';

--- a/lib/src/televerse/context/callback_query.dart
+++ b/lib/src/televerse/context/callback_query.dart
@@ -16,13 +16,18 @@ class CallbackQueryContext extends Context with CallbackQueryMixin {
   String? get data => query.data;
 
   /// The message of the query.
-  Message? get message => query.message;
+  MaybeInaccessibleMessage? get message => query.message;
 
   /// The chat of the query.
   Chat? get chat => message?.chat;
 
   /// The user of the query.
-  User? get from => message?.from;
+  User? get from {
+    if (message?.isInaccessible ?? true) {
+      return null;
+    }
+    return (message as Message?)?.from;
+  }
 
   /// The list of regex matches.
   List<RegExpMatch>? matches;

--- a/lib/src/types/message_origin_type.dart
+++ b/lib/src/types/message_origin_type.dart
@@ -1,6 +1,6 @@
 part of 'types.dart';
 
-/// The type of a [MessageOrigin].
+/// The type of a `MessageOrigin
 enum MessageOriginType {
   /// User
   user._('user'),

--- a/lib/src/types/message_origin_type.dart
+++ b/lib/src/types/message_origin_type.dart
@@ -1,0 +1,40 @@
+part of 'types.dart';
+
+/// The type of a [MessageOrigin].
+enum MessageOriginType {
+  /// User
+  user._('user'),
+
+  /// Hidden User
+  hiddenUser._('hidden_user'),
+
+  /// Chat
+  chat._('chat'),
+
+  /// Channel
+  channel._('channel');
+
+  /// The value of this [MessageOriginType].
+  final String value;
+
+  /// Private constructor [MessageOriginType].
+  const MessageOriginType._(this.value);
+
+  /// Returns a [MessageOriginType] based on the [value].
+  static MessageOriginType from(String value) {
+    switch (value) {
+      case 'user':
+        return user;
+      case 'hidden_user':
+        return hiddenUser;
+      case 'chat':
+        return chat;
+      case 'channel':
+        return channel;
+      default:
+        throw TeleverseException(
+          'Invalid MessageOriginType value.',
+        );
+    }
+  }
+}

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -25,3 +25,4 @@ part 'methods.dart';
 part 'passport_type.dart';
 part 'reaction_type_emoji_type.dart';
 part 'chat_boost_source_type.dart';
+part 'message_origin_type.dart';


### PR DESCRIPTION
Part of #165, fixes #175.

Other Changes

- Added support for the fields emoji_status_custom_emoji_id and emoji_status_expiration_date in the class [Chat](https://core.telegram.org/bots/api#chat) for non-private chats.
- Added the fields accent_color_id, background_custom_emoji_id, profile_accent_color_id, and profile_background_custom_emoji_id to the class [Chat](https://core.telegram.org/bots/api#chat).
- Added the field has_visible_history to the class [Chat](https://core.telegram.org/bots/api#chat).
- Added the class [MessageOrigin](https://core.telegram.org/bots/api#messageorigin) and replaced the fields forward_from, forward_from_chat, forward_from_message_id, forward_signature, forward_sender_name, and forward_date with the field forward_origin of type [MessageOrigin](https://core.telegram.org/bots/api#messageorigin) in the class [Message](https://core.telegram.org/bots/api#message).
- Improved documentation for the field message of the class [callbackQuery](https://core.telegram.org/bots/api#callbackquery) and the field pinned_message of the class [Message](https://core.telegram.org/bots/api#message) by adding the classes [MaybeInaccessibleMessage](https://core.telegram.org/bots/api#maybeinaccessiblemessage) and [InaccessibleMessage](https://core.telegram.org/bots/api#inaccessiblemessage).