### PR TITLE
New methods to Televerse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - New Context objects, `MessageReactionContext` & `MessageReactionCountUpdatedContext` to represent `message_reaction` and `message_reaction_count` updates respectively.
 - Added `Televerse.onMessageReaction` and `Televerse.onMessageReactionCount` methods to listen to `message_reaction` and `message_reaction_count` updates respectively.
+- 🆕 Added methods `MessageContext.react` and `MessageContext.reactMultiple` to react to a message.
+- 🆕 Added `Televerse.whenReacted` method to listen to particular reactions on a message.
 
 ## Replies 2.0 🗯
 

--- a/lib/src/televerse/context/mixins/message_mixin.dart
+++ b/lib/src/televerse/context/mixins/message_mixin.dart
@@ -665,4 +665,36 @@ mixin MessageMixin on Context {
         update.editedChannelPost;
     return m!;
   }
+
+  /// React to the message with a reaction.
+  Future<bool> react(
+    String emoji, {
+    bool? isBig,
+  }) async {
+    return await api.setMessageReaction(
+      id,
+      _msg.messageId,
+      reaction: [
+        ReactionTypeEmoji(emoji: emoji),
+      ],
+      isBig: isBig,
+    );
+  }
+
+  /// React to the message with multiple reactions.
+  Future<bool> reactMultiple(
+    List<String> emojis, {
+    bool? isBig,
+  }) async {
+    return await api.setMessageReaction(
+      id,
+      _msg.messageId,
+      reaction: emojis
+          .map(
+            (e) => ReactionTypeEmoji(emoji: e),
+          )
+          .toList(),
+      isBig: isBig,
+    );
+  }
 }

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -3299,11 +3299,11 @@ class RawAPI {
   /// Service messages can't be reacted to. Automatically forwarded messages from a channel to its discussion group have the same available reactions as messages in the channel.
   /// In albums, bots must react to the first message. Returns True on success.
   Future<bool> setMessageReaction(
-    dynamic chatId,
-    int messageId,
+    ID chatId,
+    int messageId, {
     List<ReactionType>? reaction,
     bool? isBig,
-  ) async {
+  }) async {
     Map<String, dynamic> params = {
       "chat_id": chatId,
       "message_id": messageId,

--- a/lib/src/televerse/televerse.dart
+++ b/lib/src/televerse/televerse.dart
@@ -2028,4 +2028,22 @@ class Televerse<TeleverseSession extends Session> {
 
     _handlerScopes.add(scope);
   }
+
+  /// Registers a callback to be fired when a user reacts given emoji to a message.
+  void whenReacted(String emoji, MessageReactionHandler callback) {
+    HandlerScope scope = HandlerScope<MessageReactionHandler>(
+      handler: callback,
+      types: [
+        UpdateType.messageReaction,
+      ],
+      predicate: (ctx) {
+        ctx as MessageReactionContext;
+        return ctx.newReaction.any((ReactionType el) {
+          return el is ReactionTypeEmoji && el.emoji == emoji;
+        });
+      },
+    );
+
+    _handlerScopes.add(scope);
+  }
 }


### PR DESCRIPTION
- 🆕 Added methods `MessageContext.react` and `MessageContext.reactMultiple` to react to a message.
- 🆕 Added `Televerse.whenReacted` method to listen to particular reactions on a message.

Part of #165.