### PR TITLE
Bot API 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.13.2
+
+- 🤖 Bot API 7.1 is here.
+- [Refer to official changelog here.](https://core.telegram.org/bots/api-changelog#february-16-2024)
+
 # 1.13.1
 
 - Improved the `Conversation` API to make it easier and more efficient to use.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 ![GitHub](https://img.shields.io/github/license/HeySreelal/televerse?color=green)
 ![](https://shields.io/badge/Latest-Bot%20API%207.0-blue)
 
-🤖 `Bot API version: Bot API 7.0 (December 29, 2023)`
+🤖 `Bot API version: Bot API 7.1 (February 16, 2024)`
 
 Televerse is a powerful, easy-to-use, and highly customizable Telegram bot framework built with Dart programming language. It provides a complete and well-structured API that enables developers to create and deploy complex Telegram bots with ease. Televerse provides a total of 0 dynamic types on its public interface, making it easy for developers to write strictly typed code.
 
-## 🔥 Latest Update: Bot API 7.0
+## 🔥 Latest Update: Bot API 7.1
 
-The biggest update to Bot API yet! Bot API 7.0 brings a lot of new features and improvements to the Telegram Bot API. Televerse 1.12.0 brings support for Bot API 7.0, and also adds a lot of new features and improvements to the Televerse API.
 
-Our favorite is the new `ctx.react()` method, which allows you to react to a message. Or let's see a quick example:
+All the changes from the latest Bot API (7.1) are now available in Televerse. This update includes new `ChatBoostAdded` service message and couple of new fields in the `Chat` object.
+
+Also feel free to try out the Bot API 7.0's reaction features with Televerse. Our favorite is the `react` method, which allows you to react to messages with emojis. For example:
 
 ```dart
   bot.start((ctx) async {

--- a/lib/src/telegram/models/chat.dart
+++ b/lib/src/telegram/models/chat.dart
@@ -107,6 +107,12 @@ class Chat {
   /// Optional. True, if new chat members will have access to old messages; available only to chat administrators. Returned only in getChat.
   final bool? hasVisibleHistory;
 
+  /// Optional. For supergroups, the minimum number of boosts that a non-administrator user needs to add in order to ignore slow mode and chat permissions. Returned only in getChat.
+  final int? unrestrictBoostCount;
+
+  /// Optional. For supergroups, the name of the group's custom emoji sticker set. Custom emoji from this set can be used by all users and bots in the group. Returned only in getChat.
+  final String? customEmojiStickerSetName;
+
   /// Constructs a [Chat] object.
   const Chat({
     required this.id,
@@ -144,6 +150,8 @@ class Chat {
     this.profileAccentColorId,
     this.profileBackgroundCustomEmojiId,
     this.hasVisibleHistory,
+    this.unrestrictBoostCount,
+    this.customEmojiStickerSetName,
   });
 
   /// Creates a [Chat] object from json.
@@ -196,6 +204,8 @@ class Chat {
       profileBackgroundCustomEmojiId:
           json['profile_background_custom_emoji_id'],
       hasVisibleHistory: json['has_visible_history'],
+      unrestrictBoostCount: json['unrestrict_boost_count'],
+      customEmojiStickerSetName: json['custom_emoji_sticker_set_name'],
     );
   }
 
@@ -239,6 +249,8 @@ class Chat {
       'profile_accent_color_id': profileAccentColorId,
       'profile_background_custom_emoji_id': profileBackgroundCustomEmojiId,
       'has_visible_history': hasVisibleHistory,
+      'unrestrict_boost_count': unrestrictBoostCount,
+      'custom_emoji_sticker_set_name': customEmojiStickerSetName,
     }..removeWhere((key, value) => value == null);
   }
 }

--- a/lib/src/telegram/models/chat_boost_added.dart
+++ b/lib/src/telegram/models/chat_boost_added.dart
@@ -24,7 +24,6 @@ class ChatBoostAdded {
     );
   }
 
-
   @override
   String toString() => 'ChatBoostAdded(boostCount: $boostCount)';
 

--- a/lib/src/telegram/models/chat_boost_added.dart
+++ b/lib/src/telegram/models/chat_boost_added.dart
@@ -1,0 +1,40 @@
+part of 'models.dart';
+
+/// This object represents a service message about a user boosting a chat.
+class ChatBoostAdded {
+  /// Number of boosts added by the user
+  final int boostCount;
+
+  /// Chat Boost Added constructor
+  const ChatBoostAdded({
+    required this.boostCount,
+  });
+
+  /// Converts a ChatBoostAdded into a Map
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'boostCount': boostCount,
+    };
+  }
+
+  /// Create a ChatBoostAdded from a Map
+  factory ChatBoostAdded.fromJson(Map<String, dynamic> map) {
+    return ChatBoostAdded(
+      boostCount: map['boostCount'] as int,
+    );
+  }
+
+
+  @override
+  String toString() => 'ChatBoostAdded(boostCount: $boostCount)';
+
+  @override
+  bool operator ==(covariant ChatBoostAdded other) {
+    if (identical(this, other)) return true;
+
+    return other.boostCount == boostCount;
+  }
+
+  @override
+  int get hashCode => boostCount.hashCode;
+}

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -230,6 +230,15 @@ class Message implements MaybeInaccessibleMessage, WithUser {
   /// Optional. Service message: a giveaway without public winners was completed
   final GiveawayCompleted? giveawayCompleted;
 
+  /// Optional. Service message: user boosted the chat
+  final ChatBoostAdded? boostAdded;
+
+  /// Optional. If the sender of the message boosted the chat, the number of boosts added by the user
+  final int? senderBoostCount;
+
+  /// Optional. For replies to a story, the original story
+  final Story? replyToStory;
+
   /// Creates a Message object.
   const Message({
     this.from,
@@ -306,6 +315,9 @@ class Message implements MaybeInaccessibleMessage, WithUser {
     required this.chat,
     required this.date,
     required this.messageId,
+    this.boostAdded,
+    this.senderBoostCount,
+    this.replyToStory,
   });
 
   /// Creates a [Message] object from json map.
@@ -473,6 +485,15 @@ class Message implements MaybeInaccessibleMessage, WithUser {
       forwardOrigin: json['forward_origin'] == null
           ? null
           : MessageOrigin.fromJson(json['forward_origin']),
+      boostAdded: json["boost_added"] != null
+          ? ChatBoostAdded.fromJson(
+              json["boost_added"],
+            )
+          : null,
+      senderBoostCount: json["sender_boost_count"],
+      replyToStory: json["reply_to_story"] != null
+          ? Story.fromJson(json["reply_to_story"])
+          : null,
     );
   }
 
@@ -555,6 +576,9 @@ class Message implements MaybeInaccessibleMessage, WithUser {
       'giveaway_winners': giveawayWinners?.toJson(),
       'giveaway_completed': giveawayCompleted?.toJson(),
       'forward_origin': forwardOrigin?.toJson(),
+      'boost_added': boostAdded?.toJson(),
+      'sender_boost_count': senderBoostCount,
+      'reply_to_story': replyToStory?.toJson(),
     }..removeWhere((key, value) => value == null);
   }
 

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -196,3 +196,7 @@ part 'message_origin_chat.dart';
 part 'message_origin_channel.dart';
 part 'abstracts/maybe_inaccessible_message.dart';
 part 'inaccessible_message.dart';
+
+// Bot API 7.1
+
+part 'chat_boost_added.dart';

--- a/lib/src/telegram/models/story.dart
+++ b/lib/src/telegram/models/story.dart
@@ -1,15 +1,32 @@
 part of 'models.dart';
 
-/// This object represents a message about a forwarded story in the chat. Currently holds no information.
+/// This object represents a message about a forwarded story in the chat.
 class Story {
+  /// Chat that posted the story
+  final Chat chat;
+
+  /// Unique identifier for the story in the chat
+  final int id;
+
   /// Constructs an instance of Story.
-  const Story();
+  const Story({
+    required this.chat,
+    required this.id,
+  });
 
   /// Constructs an instance of Story from a JSON map.
   factory Story.fromJson(Map<String, dynamic> json) {
-    return Story();
+    return Story(
+      chat: Chat.fromJson(json['chat'] as Map<String, dynamic>),
+      id: json['id'] as int,
+    );
   }
 
   /// Returns JSON-encodeable map of this object.
-  Map<String, dynamic> toJson() => <String, dynamic>{};
+  Map<String, dynamic> toJson() {
+    return {
+      'chat': chat.toJson(),
+      'id': id,
+    };
+  }
 }

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -370,7 +370,7 @@ class Bot<TeleverseSession extends Session> {
       bot = me;
     } catch (err) {
       try {
-        bot = await api.getMe();
+        bot = await getMe();
         _me = bot;
       } catch (err, st) {
         if (_onError != null) {
@@ -387,11 +387,11 @@ class Bot<TeleverseSession extends Session> {
       handler: callback,
       types: [UpdateType.message],
       predicate: (ctx) {
-        if (ctx.message?.text == null) return false;
+        if (ctx.msg?.text == null) return false;
         if (command is RegExp) {
-          return command.hasMatch(ctx.message?.text ?? "");
+          return command.hasMatch(ctx.msg?.text ?? "");
         } else if (command is String) {
-          final firstTerm = ctx.message?.text!.split(' ').first;
+          final firstTerm = ctx.msg?.text!.split(' ').first;
           final suffix = bot?.username != null ? '@${bot?.username}' : '';
           return firstTerm == '/$command' || firstTerm == '/$command$suffix';
         }
@@ -638,12 +638,12 @@ class Bot<TeleverseSession extends Session> {
   }
 
   /// Registers a callback for the `/settings` command.
-  Future<void> settings(Handler handler) {
+  Future<void> settings(Handler<TeleverseSession> handler) {
     return command("settings", handler);
   }
 
   /// Registers a callback for the `/help` command.
-  Future<void> help(Handler handler) {
+  Future<void> help(Handler<TeleverseSession> handler) {
     return command("help", handler);
   }
 

--- a/lib/src/televerse/models/logger_options.dart
+++ b/lib/src/televerse/models/logger_options.dart
@@ -40,7 +40,7 @@ class LoggerOptions {
   /// - [stackTrace] - Print error stack trace [DioException.stackTrace]
   /// - [logPrint] - Log printer; defaults print log to console.
   /// - [methods] - Methods to be logged.
-  LoggerOptions({
+  const LoggerOptions({
     this.request = true,
     this.requestHeader = true,
     this.requestBody = true,
@@ -53,31 +53,31 @@ class LoggerOptions {
   }) : methods = methods ?? APIMethod.values; // Default all methods
 
   /// Print request [Options]
-  bool request;
+  final bool request;
 
   /// Print request header [Options.headers]
-  bool requestHeader;
+  final bool requestHeader;
 
   /// Print request data [Options]
-  bool requestBody;
+  final bool requestBody;
 
   /// Print [Response.data]
-  bool responseBody;
+  final bool responseBody;
 
   /// Print [Response.headers]
-  bool responseHeader;
+  final bool responseHeader;
 
   /// Print error message
-  bool error;
+  final bool error;
 
   /// Print error stack trace [DioException.stackTrace]
-  bool stackTrace;
+  final bool stackTrace;
 
   /// Log printer; defaults print log to console.
-  void Function(Object object) logPrint;
+  final void Function(Object object) logPrint;
 
   /// Methods to be logged.
-  List<APIMethod> methods;
+  final List<APIMethod> methods;
 
   /// Returns true if the given [method] is allowed.
   bool isAllowed(APIMethod method) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.0!
-version: 1.13.1
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.1!
+version: 1.13.2
 homepage: https://github.com/HeySreelal/televerse
 topics:
   - telegram


### PR DESCRIPTION
Bot API 7.1

- Added support for the administrator rights can_post_stories, can_edit_stories, can_delete_stories in supergroups.
- Added the class [ChatBoostAdded](https://core.telegram.org/bots/api#chatboostadded) and the field boost_added to the class [Message](https://core.telegram.org/bots/api#message) for service messages about a user boosting a chat.
- Added the field sender_boost_count to the class [Message](https://core.telegram.org/bots/api#message).
- Added the field reply_to_story to the class [Message](https://core.telegram.org/bots/api#message).
- Added the fields chat and id to the class [Story](https://core.telegram.org/bots/api#story).
- Added the field unrestrict_boost_count to the class [Chat](https://core.telegram.org/bots/api#chat).
- Added the field custom_emoji_sticker_set_name to the class [Chat](https://core.telegram.org/bots/api#chat).