### PR TITLE
⏰ Timeout and `closeClient`

### DIFF
--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -34,6 +34,11 @@ class Bot<TeleverseSession extends Session> {
   /// Handler for unexpected errors.
   FutureOr<void> Function(BotError error)? _onError;
 
+  /// The timeout duration for the requests.
+  ///
+  /// This is used to set the timeout duration for the requests. When the timeout duration is reached, the request will be cancelled.
+  final Duration? timeout;
+
   /// Get the bot instance.
   ///
   /// This getter returns the bot instance. You can use this to access the bot instance from anywhere in your code.
@@ -69,6 +74,7 @@ class Bot<TeleverseSession extends Session> {
         baseUrl: _baseURL,
         scheme: _scheme,
         loggerOptions: _loggerOptions,
+        timeout: timeout,
       );
     }
     return RawAPI(
@@ -76,6 +82,7 @@ class Bot<TeleverseSession extends Session> {
       baseUrl: _baseURL,
       scheme: APIScheme.https,
       loggerOptions: _loggerOptions,
+      timeout: timeout,
     );
   }
 
@@ -100,6 +107,7 @@ class Bot<TeleverseSession extends Session> {
     String baseURL = RawAPI.defaultBase,
     APIScheme scheme = APIScheme.https,
     LoggerOptions? loggerOptions,
+    this.timeout,
   })  : _baseURL = baseURL,
         isLocal = baseURL != RawAPI.defaultBase,
         _loggerOptions = loggerOptions,
@@ -110,10 +118,16 @@ class Bot<TeleverseSession extends Session> {
 
     api.getMe().then((value) {
       _me = value;
-    }).catchError((err, st) async {
+    }).catchError((Object err, StackTrace st) async {
       if (_onError != null) {
         final botErr = BotError(err, st);
         await _onError!(botErr);
+      } else if (err is DioException) {
+        if (err.type == DioExceptionType.connectionTimeout ||
+            err.type == DioExceptionType.receiveTimeout ||
+            err.type == DioExceptionType.sendTimeout) {
+          throw TeleverseException.timeoutException(st, timeout!);
+        }
       } else {
         throw err;
       }
@@ -151,6 +165,7 @@ class Bot<TeleverseSession extends Session> {
     String baseURL = "localhost:8081",
     APIScheme scheme = APIScheme.http,
     LoggerOptions? loggerOptions,
+    Duration? timeout,
   }) {
     print('Using local Bot API server at $baseURL');
     return Bot(
@@ -159,6 +174,7 @@ class Bot<TeleverseSession extends Session> {
       baseURL: baseURL,
       scheme: scheme,
       loggerOptions: loggerOptions,
+      timeout: timeout,
     );
   }
 

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -305,7 +305,12 @@ class Bot<TeleverseSession extends Session> {
   }
 
   /// Stop listening for updates.
-  Future<void> stop() {
+  Future<void> stop({
+    bool shouldCloseHttpClient = true,
+  }) {
+    if (shouldCloseHttpClient) {
+      api.closeClient();
+    }
     return fetcher.stop();
   }
 

--- a/lib/src/televerse/models/televerse_exception.dart
+++ b/lib/src/televerse/models/televerse_exception.dart
@@ -62,4 +62,18 @@ class TeleverseException implements Exception {
         description:
             "You must provide the bytes of the file to upload. Use the `InputFile.fromBytes` constructor to create an InputFile.",
       );
+
+  /// Exception thrown when the timeout exception occurs.
+  static TeleverseException timeoutException(StackTrace st, Duration timeout) {
+    return TeleverseException(
+      "Connection timeout.",
+      description:
+          "The request took too long to complete. This might be due to a slow internet connection or sometimes due to the Telegram servers. Try again later.\n\n"
+          "Possible solutions:\n"
+          "   1. Increase the timeout duration. Currently it is set to $timeout.\n"
+          "   2. Check your internet connection.\n"
+          "   3. Attach a error handler using `Bot.onError` to handle the timeout exception.",
+      stackTrace: st,
+    );
+  }
 }

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -2,6 +2,11 @@ part of '../../televerse.dart';
 
 /// Raw API for the Telegram Bot API.
 class RawAPI {
+  /// Timeout Duration for the HTTP client.
+  ///
+  /// When the timeout is reached, the API request will be cancelled and the client will throw an exception.
+  final Duration? timeout;
+
   /// API Scheme
   final APIScheme _scheme;
 
@@ -23,10 +28,14 @@ class RawAPI {
     String? baseUrl,
     APIScheme? scheme,
     LoggerOptions? loggerOptions,
+    this.timeout,
   })  : _baseUrl = baseUrl ?? defaultBase,
         _isLocal = baseUrl != defaultBase,
         _scheme = scheme ?? APIScheme.https,
-        _httpClient = _HttpClient(loggerOptions);
+        _httpClient = _HttpClient(
+          loggerOptions,
+          timeout: timeout,
+        );
 
   /// Creates a new RawAPI instance with the given [token] and [baseUrl].
   ///
@@ -36,12 +45,14 @@ class RawAPI {
     String baseUrl = "localhost:8081",
     APIScheme scheme = APIScheme.http,
     LoggerOptions? loggerOptions,
+    Duration? timeout,
   }) {
     return RawAPI(
       token,
       baseUrl: baseUrl,
       scheme: scheme,
       loggerOptions: loggerOptions,
+      timeout: timeout,
     );
   }
 

--- a/lib/src/televerse/raw_api.dart
+++ b/lib/src/televerse/raw_api.dart
@@ -15,7 +15,7 @@ class RawAPI {
   final String token;
 
   /// Http client
-  final HttpClient _httpClient;
+  final _HttpClient _httpClient;
 
   /// The Raw API.
   RawAPI(
@@ -26,7 +26,7 @@ class RawAPI {
   })  : _baseUrl = baseUrl ?? defaultBase,
         _isLocal = baseUrl != defaultBase,
         _scheme = scheme ?? APIScheme.https,
-        _httpClient = HttpClient(loggerOptions);
+        _httpClient = _HttpClient(loggerOptions);
 
   /// Creates a new RawAPI instance with the given [token] and [baseUrl].
   ///
@@ -93,6 +93,11 @@ class RawAPI {
       };
     }).toList();
     return files;
+  }
+
+  /// Close the HTTP client.
+  void closeClient() {
+    _httpClient.close();
   }
 
   /// Use this method to receive incoming updates using long polling.

--- a/lib/src/utils/http.dart
+++ b/lib/src/utils/http.dart
@@ -1,11 +1,9 @@
-import 'dart:convert';
-import 'package:dio/dio.dart';
-import 'package:televerse/televerse.dart';
+part of '../../televerse.dart';
 
 /// HttpClient is used to send HTTP requests to the Telegram Bot API.
-class HttpClient {
+class _HttpClient {
   /// Construc client with optionally logging
-  HttpClient(this.loggerOptions) {
+  _HttpClient(this.loggerOptions) {
     if (loggerOptions != null) {
       _dio.interceptors.add(
         loggerOptions!.interceptor,
@@ -126,5 +124,10 @@ class HttpClient {
       return MapEntry(k, jsonEncode(v));
     }
     return MapEntry(k, "$v");
+  }
+
+  /// Close the client
+  void close() {
+    _dio.close();
   }
 }

--- a/lib/src/utils/http.dart
+++ b/lib/src/utils/http.dart
@@ -3,7 +3,10 @@ part of '../../televerse.dart';
 /// HttpClient is used to send HTTP requests to the Telegram Bot API.
 class _HttpClient {
   /// Construc client with optionally logging
-  _HttpClient(this.loggerOptions) {
+  _HttpClient(
+    this.loggerOptions, {
+    this.timeout,
+  }) {
     if (loggerOptions != null) {
       _dio.interceptors.add(
         loggerOptions!.interceptor,
@@ -16,6 +19,18 @@ class _HttpClient {
 
   /// Log flag
   final LoggerOptions? loggerOptions;
+
+  /// Timeout for the requests
+  final Duration? timeout;
+
+  /// Returns the timeout duration for the given [uri]. The [timeout] will not be used for `getUpdates` requests.
+  Duration? _timeoutDuration(Uri uri) {
+    // If the URI is of getUpdates, ignore the timeout.
+    if (uri.pathSegments.last == APIMethod.getUpdates.name) {
+      return null;
+    }
+    return timeout;
+  }
 
   // Throws formatted exception
   void _dioCatch(Object? e) {
@@ -68,6 +83,8 @@ class _HttpClient {
         data: bodyContent,
         options: Options(
           headers: {"Content-Type": "application/json"},
+          sendTimeout: _timeoutDuration(uri),
+          receiveTimeout: _timeoutDuration(uri),
         ),
       );
       final resBody = response.data;

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -27,7 +27,6 @@ import 'dart:math';
 import 'package:dio/dio.dart';
 import 'package:televerse/telegram.dart';
 import 'package:televerse/televerse.dart';
-import 'package:televerse/src/utils/http.dart';
 
 export 'src/televerse/models/models.dart';
 export 'src/types/types.dart';
@@ -35,6 +34,7 @@ export 'src/televerse/fetch/fetch.dart';
 export 'src/televerse/extensions/extensions.dart';
 export 'src/televerse/links/links.dart';
 
+part 'src/utils/http.dart';
 part 'src/televerse/bot.dart';
 part 'src/utils/date.dart';
 part 'src/utils/utils.dart';


### PR DESCRIPTION
- Televerse now supports adding timeout for API requests. Both `Bot` class and `RawAPI` class accepts a new field `timeout` of type `Duration` for achieving this.
  
  Note that, the timeout duration will NOT affect the `getUpdates` requests.

- Renamed the HttpClient class to private class.
- Added `RawAPI.closeClient` method to close the Dio client.