### PR TITLE
🚀 Televerse v1.15.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
+# 1.15.10
+
+- Added `Bot.fromAPI` constructor for creating Bot instance from `RawAPI` instance.
+- `Bot.command`, `Bot.text`, `Bot.hears`, and many more methods now listens to all Message types (Message, Channel Posts, and edited messages of both)
+- ⚠️ Added `chatId` parameter to `Bot.shippingQuery` and `Bot.preCheckoutQuery`.
+- Refactored code for quality and better readability and added docs.
+- Added `ScopeOptions` class that can contain additional info for handler scope.
+- `ScopeOptions.forked` to create forked handlers. Forked handlers are run without conditions.
+- `ScopeOptions.customPredicate` can be used to set a middleware to check if the update should be processed or skipped.
+- Migrated to `Dart 3.0.0`
+- `Bot.removeScope` can be used to remove already set handlers.
+- Accepts `ScopeOption` on both menus as well.
+
 # 1.15.9
 
 - Improved efficiency by removing redundant `getMe` calls while registering `command` handlers and `whenMentioned` handlers.
 - Made `LongPolling.allowedUpdates` nullable, and removed the constant empty list initialization. 
 - Updated the README.
-
 
 # 1.15.8
 

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -2188,28 +2188,28 @@ class Bot {
 
           final action = menu._buttons[i][j].handler as Handler;
           switch (menu._buttons[i][j].runtimeType) {
-            case _KeyboardMenuTextButton _:
+            case const (_KeyboardMenuTextButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.text == text,
                 options: ScopeOptions(name: name),
               );
               break;
-            case _KeyboardMenuRequestContactButton _:
+            case const (_KeyboardMenuRequestContactButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.contact != null,
                 options: ScopeOptions(name: name),
               );
               break;
-            case _KeyboardMenuRequestLocationButton _:
+            case const (_KeyboardMenuRequestLocationButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.location != null,
                 options: ScopeOptions(name: name),
               );
               break;
-            case _KeyboardMenuRequestUsersButton _:
+            case const (_KeyboardMenuRequestUsersButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.usersShared != null,

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -414,7 +414,7 @@ class Bot {
       final scope = HandlerScope(
         isCommand: true,
         handler: callback,
-        types: [UpdateType.message],
+        types: UpdateType.messages(),
         predicate: (ctx) {
           if (ctx.msg?.text == null) return false;
           if (command is RegExp) {

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -406,10 +406,10 @@ class Bot {
   /// ```
   ///
   /// This will reply "Hello!" to any message that starts with `/start`.
-  Future<void> command(
+  void command(
     Pattern command,
     Handler callback,
-  ) async {
+  ) {
     if (initialized) {
       final scope = HandlerScope(
         isCommand: true,
@@ -674,12 +674,12 @@ class Bot {
   }
 
   /// Registers a callback for the `/settings` command.
-  Future<void> settings(Handler handler) {
+  void settings(Handler handler) {
     return command("settings", handler);
   }
 
   /// Registers a callback for the `/help` command.
-  Future<void> help(Handler handler) {
+  void help(Handler handler) {
     return command("help", handler);
   }
 
@@ -772,9 +772,7 @@ class Bot {
   }) {
     final scope = HandlerScope(
       handler: callback,
-      types: [
-        UpdateType.message,
-      ],
+      types: UpdateType.messages(),
       predicate: (ctx) {
         return _internalEntityMatcher(
           context: ctx,
@@ -802,9 +800,7 @@ class Bot {
   }) {
     final scope = HandlerScope(
       handler: callback,
-      types: [
-        UpdateType.message,
-      ],
+      types: UpdateType.messages(),
       predicate: (ctx) {
         List<MessageEntity>? entities = ctx.message?.entities;
         if (shouldMatchCaptionEntities) {

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -604,11 +604,9 @@ class Bot {
   ) {
     final scope = HandlerScope(
       handler: callback,
-      types: [
-        UpdateType.message,
-      ],
+      types: UpdateType.messages(),
       predicate: (ctx) {
-        return ctx.message?.text == text;
+        return ctx.msg?.text == text;
       },
     );
 

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -59,6 +59,7 @@ class Bot {
     }
   }
 
+  /// Raw API instance associated with this bot instance (internal)
   RawAPI? _api;
 
   /// Raw API - gives you access to all the methods of Telegram Bot API.
@@ -257,6 +258,7 @@ class Bot {
         for (final fn in _pendingCalls) {
           fn.call();
         }
+        _pendingCalls.clear();
       }
 
       return _me;

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -465,6 +465,22 @@ class Bot {
     _handlerScopes.add(scope);
   }
 
+  /// Adds Handler Scope for a Accept-All predicate
+  void _acceptAll(
+    Handler callback,
+    List<UpdateType> types, {
+    String? name,
+  }) {
+    final scope = HandlerScope(
+      name: name,
+      handler: callback,
+      types: types,
+      predicate: (_) => true,
+    );
+
+    _handlerScopes.add(scope);
+  }
+
   /// Registers a callback for a callback query.
   ///
   /// The callback will be called when a callback query is received that has
@@ -891,16 +907,11 @@ class Bot {
   }
 
   /// Registers a callback for the [Update.poll] events.
-  void poll(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.poll,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void poll(
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.poll], name: name);
   }
 
   /// Registers a callback for the [Update.pollAnswer] events.
@@ -927,17 +938,10 @@ class Bot {
   /// Registers a callback for the [Update.chosenInlineResult] events.
   /// The callback will be called when a chosen inline result is received.
   void chosenInlineResult(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chosenInlineResult,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.chosenInlineResult], name: name);
   }
 
   /// Registers a callback for the [Update.chatJoinRequest] events of the particular chat mentioned by the chatId.
@@ -1144,193 +1148,82 @@ class Bot {
   }
 
   /// Registers a callback for all Message updates
-  void onMessage(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.message,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onMessage(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.message], name: name);
   }
 
   /// Registers a callback for all Edited Message updates
-  void onEditedMessage(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.editedMessage,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onEditedMessage(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.editedMessage], name: name);
   }
 
   /// Registers a callback for all Channel Post updates
-  void onChannelPost(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.channelPost,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onChannelPost(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.channelPost], name: name);
   }
 
   /// Registers a callback for all Edited Channel Post updates
-  void onEditedChannelPost(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.editedChannelPost,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onEditedChannelPost(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.editedChannelPost], name: name);
   }
 
   /// Registers a callback for all Inline Query updates
-  void onInlineQuery(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.inlineQuery,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onInlineQuery(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.inlineQuery], name: name);
   }
 
   /// Registers a callback for all Chosen Inline Result updates
-  void onChosenInlineResult(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chosenInlineResult,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onChosenInlineResult(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.chosenInlineResult], name: name);
   }
 
   /// Registers a callback for all Callback Query updates
-  void onCallbackQuery(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.callbackQuery,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onCallbackQuery(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.callbackQuery], name: name);
   }
 
   /// Registers a callback for all Shipping Query updates
-  void onShippingQuery(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.shippingQuery,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onShippingQuery(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.shippingQuery], name: name);
   }
 
   /// Registers a callback for all Pre Checkout Query updates
-  void onPreCheckoutQuery(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.preCheckoutQuery,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onPreCheckoutQuery(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.preCheckoutQuery], name: name);
   }
 
   /// Registers a callback to be fired for all successful payments
-  void onSuccessfulPayment(Handler callback) {
+  void onSuccessfulPayment(Handler callback, {String? name}) {
     return _internalSubMessageHandler(
       callback,
       (ctx) => ctx.message?.successfulPayment != null,
+      name: name,
     );
   }
 
   /// Registers a callback for all Poll updates
-  void onPoll(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.poll,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onPoll(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.poll], name: name);
   }
 
   /// Registers a callback for all Poll Answer updates
-  void onPollAnswer(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.pollAnswer,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onPollAnswer(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.pollAnswer], name: name);
   }
 
   /// Registers a callback for all My Chat Member updates
-  void onMyChatMember(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.myChatMember,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onMyChatMember(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.myChatMember], name: name);
   }
 
   /// Registers a callback for all Chat Member updates
-  void onChatMember(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chatMember,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onChatMember(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.chatMember], name: name);
   }
 
   /// Registers a callback for all Chat Join Request updates
-  void onChatJoinRequest(Handler callback) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chatJoinRequest,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+  void onChatJoinRequest(Handler callback, {String? name}) {
+    return _acceptAll(callback, [UpdateType.chatJoinRequest], name: name);
   }
 
   /// On Stop Handler
@@ -2077,66 +1970,38 @@ class Bot {
 
   /// Register a callback when a reaction to a message was changed by a user.
   void onMessageReaction(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.messageReaction,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.messageReaction], name: name);
   }
 
   /// Reactions to a message with anonymous reactions were changed.
   void onMessageReactionCount(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.messageReactionCount,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.messageReactionCount], name: name);
   }
 
   /// Registers a callback for when the chat was boosted.
   ///
   /// The bot must be an administrator in the chat for this to work.
   void onChatBoosted(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chatBoost,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.chatBoost], name: name);
   }
 
   /// Registers a callback to be fired when the chat boost was removed.
   ///
   /// The bot must be an administrator in the chat for this to work.
   void onChatBoostRemoved(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.chatBoostRemoved,
-      ],
-      predicate: (ctx) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.chatBoostRemoved], name: name);
   }
 
   /// Registers a callback to be fired when a user reacts given emoji to a message.
@@ -2166,61 +2031,37 @@ class Bot {
 
   /// Registers a callback to be fired when a connection of the bot with a business account is made.
   void onBusinessConnection(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.businessConnection,
-      ],
-      predicate: (_) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.businessConnection], name: name);
   }
 
   /// Registers callback to be fired when a new message is received in a business account connected to the bot.
   void onBusinessMessage(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.businessMessage,
-      ],
-      predicate: (_) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.businessMessage], name: name);
   }
 
   /// Registers a callback to be fired when a business message is edited.
   void onBusinessMessageEdited(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.editedBusinessMessage,
-      ],
-      predicate: (_) => true,
-    );
-
-    _handlerScopes.add(scope);
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(callback, [UpdateType.channelPost], name: name);
   }
 
   /// Registers a callback to be fired when a business message is deleted.
   void onBusinessMessageDeleted(
-    Handler callback,
-  ) {
-    final scope = HandlerScope(
-      handler: callback,
-      types: [
-        UpdateType.deletedBusinessMessages,
-      ],
-      predicate: (_) => true,
+    Handler callback, {
+    String? name,
+  }) {
+    return _acceptAll(
+      callback,
+      [UpdateType.deletedBusinessMessages],
+      name: name,
     );
-
-    _handlerScopes.add(scope);
   }
 }

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -2183,37 +2183,38 @@ class Bot {
       for (int i = 0; i < rows; i++) {
         int cols = menu._buttons[i].length;
         for (int j = 0; j < cols; j++) {
-          final text = menu._buttons[i][j].text;
+          final button = menu._buttons[i][j];
+          final text = button.text;
           final name = "${menu.name}-$text";
 
-          final action = menu._buttons[i][j].handler as Handler;
-          switch (menu._buttons[i][j].runtimeType) {
+          final action = button.handler as Handler;
+          switch (button.runtimeType) {
             case const (_KeyboardMenuTextButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.text == text,
-                options: ScopeOptions(name: name),
+                options: ScopeOptions._createOrCopy(button.options, name: name),
               );
               break;
             case const (_KeyboardMenuRequestContactButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.contact != null,
-                options: ScopeOptions(name: name),
+                options: ScopeOptions._createOrCopy(button.options, name: name),
               );
               break;
             case const (_KeyboardMenuRequestLocationButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.location != null,
-                options: ScopeOptions(name: name),
+                options: ScopeOptions._createOrCopy(button.options, name: name),
               );
               break;
             case const (_KeyboardMenuRequestUsersButton):
               _internalSubMessageHandler(
                 action,
                 (ctx) => ctx.message?.usersShared != null,
-                options: ScopeOptions(name: name),
+                options: ScopeOptions._createOrCopy(button.options, name: name),
               );
           }
         }

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -637,11 +637,9 @@ class Bot {
       pattern: exp,
       isRegExp: true,
       handler: callback,
-      types: [
-        UpdateType.message,
-      ],
+      types: UpdateType.messages(),
       predicate: (ctx) {
-        return exp.hasMatch(ctx.message?.text ?? '');
+        return exp.hasMatch(ctx.msg?.text ?? '');
       },
     );
 

--- a/lib/src/televerse/conversation/conversation.dart
+++ b/lib/src/televerse/conversation/conversation.dart
@@ -383,7 +383,7 @@ class Conversation {
     _bot._handlerScopes.add(
       HandlerScope(
         isConversation: true,
-        name: scopeName,
+        options: ScopeOptions(name: scopeName),
         predicate: (ctx) =>
             _isSameChat(ctx.update, chatId) && filter(ctx.update),
         types: UpdateType.values,

--- a/lib/src/televerse/markups/inline_menu.dart
+++ b/lib/src/televerse/markups/inline_menu.dart
@@ -7,8 +7,12 @@ class _InlineMenuCallbackDataButton extends _TMenuButton {
   const _InlineMenuCallbackDataButton(
     super.text,
     this.data,
-    Handler handler,
-  ) : super(hasHandler: true, handler: handler);
+    Handler handler, {
+    super.options,
+  }) : super(
+          hasHandler: true,
+          handler: handler,
+        );
 
   @override
   Map<String, dynamic> toJson() {
@@ -209,6 +213,7 @@ class InlineMenu implements InlineKeyboardMarkup, TeleverseMenu {
     String text,
     Handler handler, {
     required String data,
+    ScopeOptions? options,
   }) {
     if (_buttons.isEmpty) _buttons.add([]);
     _buttons.last.add(
@@ -216,6 +221,7 @@ class InlineMenu implements InlineKeyboardMarkup, TeleverseMenu {
         text,
         data,
         handler,
+        options: options,
       ),
     );
     inlineKeyboard = TeleverseMenu._makeInlineKeyboard(_buttons);

--- a/lib/src/televerse/markups/keyboard_menu.dart
+++ b/lib/src/televerse/markups/keyboard_menu.dart
@@ -3,8 +3,9 @@ part of '../../../televerse.dart';
 class _KeyboardMenuTextButton extends _TMenuButton {
   const _KeyboardMenuTextButton(
     super.text,
-    Handler handler,
-  ) : super(hasHandler: true, handler: handler);
+    Handler handler, {
+    super.options,
+  }) : super(hasHandler: true, handler: handler);
 
   @override
   Map<String, dynamic> toJson() {
@@ -20,7 +21,9 @@ class _KeyboardMenuRequestUsersButton extends _TMenuButton {
   const _KeyboardMenuRequestUsersButton(
     super.text,
     this.requestUsers,
-  ) : super(hasHandler: true);
+    Handler handler, {
+    super.options,
+  }) : super(hasHandler: true, handler: handler);
 
   @override
   Map<String, dynamic> toJson() {
@@ -37,8 +40,9 @@ class _KeyboardMenuRequestChatButton extends _TMenuButton {
   const _KeyboardMenuRequestChatButton(
     super.text,
     this.requestChat,
-    Handler handler,
-  ) : super(hasHandler: true, handler: handler);
+    Handler handler, {
+    super.options,
+  }) : super(hasHandler: true, handler: handler);
 
   @override
   Map<String, dynamic> toJson() {
@@ -52,8 +56,9 @@ class _KeyboardMenuRequestChatButton extends _TMenuButton {
 class _KeyboardMenuRequestContactButton extends _TMenuButton {
   const _KeyboardMenuRequestContactButton(
     super.text,
-    Handler handler,
-  ) : super(hasHandler: true, handler: handler);
+    Handler handler, {
+    super.options,
+  }) : super(hasHandler: true, handler: handler);
 
   @override
   Map<String, dynamic> toJson() {
@@ -67,8 +72,9 @@ class _KeyboardMenuRequestContactButton extends _TMenuButton {
 class _KeyboardMenuRequestLocationButton extends _TMenuButton {
   const _KeyboardMenuRequestLocationButton(
     super.text,
-    Handler handler,
-  ) : super(hasHandler: true, handler: handler);
+    Handler handler, {
+    super.options,
+  }) : super(hasHandler: true, handler: handler);
 
   @override
   Map<String, dynamic> toJson() {
@@ -84,8 +90,9 @@ class _KeyboardMenuRequestPollButton extends _TMenuButton {
 
   const _KeyboardMenuRequestPollButton(
     super.text,
-    this.requestPoll,
-  ) : super(hasHandler: true);
+    this.requestPoll, {
+    super.options,
+  }) : super(hasHandler: true);
 
   @override
   Map<String, dynamic> toJson() {
@@ -155,25 +162,55 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
   }
 
   /// Add new item to the last row
-  KeyboardMenu text(String text, Handler handler) {
+  KeyboardMenu text(
+    String text,
+    Handler handler, {
+    ScopeOptions? options,
+  }) {
     if (_buttons.isEmpty) _buttons.add([]);
-    _buttons.last.add(_KeyboardMenuTextButton(text, handler));
+    _buttons.last.add(
+      _KeyboardMenuTextButton(
+        text,
+        handler,
+        options: options,
+      ),
+    );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
     return this;
   }
 
   /// Request contact from the user
-  KeyboardMenu requestContact(String text, Handler handler) {
+  KeyboardMenu requestContact(
+    String text,
+    Handler handler, {
+    ScopeOptions? options,
+  }) {
     if (_buttons.isEmpty) _buttons.add([]);
-    _buttons.last.add(_KeyboardMenuRequestContactButton(text, handler));
+    _buttons.last.add(
+      _KeyboardMenuRequestContactButton(
+        text,
+        handler,
+        options: options,
+      ),
+    );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
     return this;
   }
 
   /// Request location from the user
-  KeyboardMenu requestLocation(String text, Handler handler) {
+  KeyboardMenu requestLocation(
+    String text,
+    Handler handler, {
+    ScopeOptions? options,
+  }) {
     if (_buttons.isEmpty) _buttons.add([]);
-    _buttons.last.add(_KeyboardMenuRequestLocationButton(text, handler));
+    _buttons.last.add(
+      _KeyboardMenuRequestLocationButton(
+        text,
+        handler,
+        options: options,
+      ),
+    );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
     return this;
   }
@@ -185,6 +222,7 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
     required int requestId,
     bool? userIsBot,
     bool? userIsPremium,
+    ScopeOptions? options,
   }) {
     if (_buttons.isEmpty) _buttons.add([]);
     _buttons.last.add(
@@ -196,6 +234,8 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
           userIsPremium: userIsPremium,
           maxQuantity: 1,
         ),
+        handler,
+        options: options,
       ),
     );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
@@ -210,6 +250,7 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
     bool? userIsBot,
     bool? userIsPremium,
     int? maxQuantity,
+    ScopeOptions? options,
   }) {
     if (_buttons.isEmpty) _buttons.add([]);
     _buttons.last.add(
@@ -221,6 +262,8 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
           userIsPremium: userIsPremium,
           maxQuantity: maxQuantity,
         ),
+        handler,
+        options: options,
       ),
     );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
@@ -239,6 +282,7 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
     ChatAdministratorRights? userAdministratorRights,
     ChatAdministratorRights? botAdministratorRights,
     bool? botIsMember,
+    ScopeOptions? options,
   }) {
     if (_buttons.isEmpty) _buttons.add([]);
     _buttons.last.add(
@@ -255,6 +299,7 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
           botIsMember: botIsMember,
         ),
         handler,
+        options: options,
       ),
     );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
@@ -270,9 +315,19 @@ class KeyboardMenu implements ReplyKeyboardMarkup, TeleverseMenu {
   }
 
   /// Add a poll button to the last row
-  KeyboardMenu requestPoll(String text, KeyboardButtonPollType requestPoll) {
+  KeyboardMenu requestPoll(
+    String text,
+    KeyboardButtonPollType requestPoll, {
+    ScopeOptions? options,
+  }) {
     if (_buttons.isEmpty) _buttons.add([]);
-    _buttons.last.add(_KeyboardMenuRequestPollButton(text, requestPoll));
+    _buttons.last.add(
+      _KeyboardMenuRequestPollButton(
+        text,
+        requestPoll,
+        options: options,
+      ),
+    );
     keyboard = TeleverseMenu._makeKeyboard(_buttons);
     return this;
   }

--- a/lib/src/televerse/markups/menu.dart
+++ b/lib/src/televerse/markups/menu.dart
@@ -5,11 +5,13 @@ abstract class _TMenuButton {
   final bool hasHandler;
   final String text;
   final Handler? handler;
+  final ScopeOptions? options;
 
   const _TMenuButton(
     this.text, {
     this.hasHandler = false,
     this.handler,
+    this.options,
   });
 
   Map<String, dynamic> toJson();

--- a/lib/src/televerse/models/chat_id.dart
+++ b/lib/src/televerse/models/chat_id.dart
@@ -19,18 +19,19 @@ abstract class ID {
   ///
   /// If the passed [value] is neither an integer nor a string, this method will throw a [TeleverseException].
   static ID create(dynamic value) {
-    switch (value.runtimeType) {
-      case int:
-        return ChatID.create(value);
-      case String:
-        return SupergroupID.create(value);
-      default:
-        throw TeleverseException(
-          "The passed value is not a valid chat id. The value must be an integer or a string.",
-          description: "The passed value is of type ${value.runtimeType}.",
-          type: TeleverseExceptionType.invalidParameter,
-        );
+    if (value is int) {
+      return ChatID.create(value);
     }
+
+    if (value is String) {
+      return ChannelID.create(value);
+    }
+
+    throw TeleverseException(
+      "The passed value is not a valid chat id. The value must be an integer or a string.",
+      description: "The passed value is of type ${value.runtimeType}.",
+      type: TeleverseExceptionType.invalidParameter,
+    );
   }
 
   /// Returns the id as a string or an integer.

--- a/lib/src/televerse/models/handler_scope.dart
+++ b/lib/src/televerse/models/handler_scope.dart
@@ -58,4 +58,7 @@ class HandlerScope {
   void executed() {
     isExecuted = true;
   }
+
+  /// Whether the scope has a custom predicate
+  bool get hasCustomPredicate => options?.customPredicate != null;
 }

--- a/lib/src/televerse/models/handler_scope.dart
+++ b/lib/src/televerse/models/handler_scope.dart
@@ -2,17 +2,6 @@ part of 'models.dart';
 
 /// A Handler Scope is used to define the scope and related information of a handler method.
 class HandlerScope {
-  /// Optional. The name of the handler. (For debugging purposes)
-  final String? name;
-
-  /// Whether the handler is a special handler.
-  ///
-  /// True if it's a command handler or a RegExp handler.
-  ///
-  /// - If it's a command handler, we set `args` to the parameter of the command.
-  /// - If it's a RegExp handler, we'll set the `MessageContext.matches` to the matches of the RegExp.
-  final bool special;
-
   /// If it's a command handler, we set `args` to the parameter of the command.
   final bool isCommand;
 
@@ -23,6 +12,8 @@ class HandlerScope {
   final RegExp? pattern;
 
   /// Handler
+  ///
+  /// Required unless [isConversation] is `true`.
   final Handler? handler;
 
   /// The update type
@@ -37,9 +28,14 @@ class HandlerScope {
   /// Chat ID of the conversation.
   final ID? chatId;
 
+  /// Scope Options - Additional parameters for the scope.
+  final ScopeOptions? options;
+
+  /// Flag whether already executed
+  bool isExecuted;
+
   /// Creates a new [HandlerScope].
-  const HandlerScope({
-    this.name,
+  HandlerScope({
     this.handler,
     required this.predicate,
     required this.types,
@@ -48,6 +44,18 @@ class HandlerScope {
     this.pattern,
     this.isConversation = false,
     this.chatId,
-  })  : special = isCommand || isRegExp,
-        assert(handler != null || isConversation);
+    this.options,
+    this.isExecuted = false,
+  }) : assert(handler != null || isConversation);
+
+  /// Whether the scope is forked or not.
+  bool get forked => options?.forked ?? false;
+
+  /// Name of the scope
+  String? get name => options?.name;
+
+  /// Sets executiion status to true.
+  void executed() {
+    isExecuted = true;
+  }
 }

--- a/lib/src/televerse/models/scope_options.dart
+++ b/lib/src/televerse/models/scope_options.dart
@@ -1,0 +1,33 @@
+part of '../../../televerse.dart';
+
+/// Represents additional options that can be passed to create Handler Scope
+class ScopeOptions {
+  /// Name of the Handler Scope.
+  ///
+  /// This can be used to remove a Handler later on your code.
+  final String? name;
+
+  /// Whether the scope is forked.
+  ///
+  /// By default fork is set to `false` that is once a matching scope is found
+  /// the processor only executes that particular scope and skips all the rest.
+  ///
+  /// When fork is set to `true` the successive Handler Scope is also considered
+  /// and executed if it satisfies the predicate.
+  final bool forked;
+
+  /// Constructs a `ScopeOption`.
+  ///
+  /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
+  ///
+  /// - [forked] - A flag used to determine whether the succeeding handler should also be executed
+  const ScopeOptions({
+    this.forked = false,
+    this.name,
+  });
+
+  /// Constructs a `ScopeOption` that is forked. This scope will allow the processing of subsequent handler scope as well.
+  ///
+  /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
+  const ScopeOptions.forked({this.name}) : forked = true;
+}

--- a/lib/src/televerse/models/scope_options.dart
+++ b/lib/src/televerse/models/scope_options.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
 part of '../../../televerse.dart';
 
 /// Represents additional options that can be passed to create Handler Scope
@@ -54,4 +55,51 @@ class ScopeOptions {
     this.name,
     this.customPredicate,
   }) : forked = true;
+
+  /// Creates a copy of this [ScopeOptions] object with potentially modified properties.
+
+  /// Provides options to override the following properties:
+  ///
+  /// * [name]: The name of the scope. If not provided, it will be inherited from the original object.
+  /// * [forked]: Whether the scope is forked. If not provided, it will be inherited from the original object.
+  /// * [customPredicate]: A custom predicate function that determines when updates within the scope are processed.
+  ///   If not provided, it will be inherited from the original object.
+  ///
+  /// The predicate function receives a [Context] object as an argument and should return a [FutureOr<bool>].
+  /// The update is only processed if the predicate function evaluates to `true`.
+  ///
+  /// Returns a new instance of [ScopeOptions] with the updated properties.
+  ScopeOptions copyWith({
+    String? name,
+    bool? forked,
+    FutureOr<bool> Function(Context ctx)? customPredicate,
+  }) {
+    return ScopeOptions(
+      name: name ?? this.name,
+      forked: forked ?? this.forked,
+      customPredicate: customPredicate ?? this.customPredicate,
+    );
+  }
+
+  /// Internal copyWith
+  static ScopeOptions _createOrCopy(
+    ScopeOptions? options, {
+    String? name,
+    bool? forked,
+    FutureOr<bool> Function(Context ctx)? customPredicate,
+  }) {
+    if (options != null) {
+      return options.copyWith(
+        name: name,
+        forked: forked,
+        customPredicate: customPredicate,
+      );
+    }
+
+    return ScopeOptions(
+      name: name,
+      forked: forked ?? false,
+      customPredicate: customPredicate,
+    );
+  }
 }

--- a/lib/src/televerse/models/scope_options.dart
+++ b/lib/src/televerse/models/scope_options.dart
@@ -16,6 +16,25 @@ class ScopeOptions {
   /// and executed if it satisfies the predicate.
   final bool forked;
 
+  /// Custom Predicate Method
+  ///
+  /// Often some handlers require restricted access, like admin controls or bans.
+  /// Checking permissions for each command can be tedious. This is where custom
+  /// predicates come in.
+  ///
+  /// By providing a custom predicate, you can control when an update is processed.
+  /// The update will only be applied if the predicate evaluates to `true`.
+  /// Otherwise, the Bot moves on to the next available handler.
+  ///
+  /// This approach keeps your code clean and avoids repetitive permission checks.
+  ///
+  /// Note: [forked] overrides this. That is even if [customPredicate] may evaluate
+  /// to `false` if [forked] is true the handler is executed.
+  ///
+  /// If by any reason, this method threw any exception, it'll be caught in the passed `Bot.onError` if set.
+  /// Otherwise, treated as `false` evaluation and skips the current handler.
+  final FutureOr<bool> Function(Context ctx)? customPredicate;
+
   /// Constructs a `ScopeOption`.
   ///
   /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
@@ -24,10 +43,15 @@ class ScopeOptions {
   const ScopeOptions({
     this.forked = false,
     this.name,
+    this.customPredicate,
   });
 
   /// Constructs a `ScopeOption` that is forked. This scope will allow the processing of subsequent handler scope as well.
   ///
   /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
-  const ScopeOptions.forked({this.name}) : forked = true;
+  /// - [customPredicate] - Middleware to check if the update should be processed or skipped.
+  const ScopeOptions.forked({
+    this.name,
+    this.customPredicate,
+  }) : forked = true;
 }

--- a/lib/src/types/update_type.dart
+++ b/lib/src/types/update_type.dart
@@ -127,4 +127,16 @@ enum UpdateType {
   factory UpdateType.fromJson(String type) {
     return UpdateType.values.firstWhere((e) => e.type == type);
   }
+
+  /// List of update types that related to a Message event.
+  static List<UpdateType> messages() {
+    return [
+      message,
+      editedMessage,
+      channelPost,
+      editedChannelPost,
+      businessMessage,
+      editedBusinessMessage,
+    ];
+  }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -110,28 +110,13 @@ enum _GetMeStatus {
 class _PendingCall {
   final Function fn;
   final List<dynamic> params;
+  final Map<Symbol, dynamic> namedParams;
 
   const _PendingCall({
     required this.fn,
     required this.params,
+    this.namedParams = const <Symbol, dynamic>{},
   });
-
-  void call() {
-    switch (params.length) {
-      case 0:
-        fn.call();
-        break;
-      case 1:
-        fn.call(params[0]);
-        break;
-      case 2:
-        fn.call(params[0], params[1]);
-        break;
-      case 3:
-        fn.call(params[0], params[1], params[2]);
-        break;
-    }
-  }
 }
 
 /// Extension on `Chat` to create ID of the chat

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -133,3 +133,49 @@ class _PendingCall {
     }
   }
 }
+
+/// Extension on `Chat` to create ID of the chat
+extension GetChatID on Chat {
+  /// Returns the `ChatID` of the chat.
+  ChatID getId() {
+    return ChatID(id);
+  }
+
+  /// Gets the chat's `ChannelID` from the username
+  ID? getChannelId() {
+    if (username != null) return ChannelID(username!);
+    return null;
+  }
+
+  /// Returns true if the [chatId] passed matches the current chat's ID.
+  bool isTheSameChat(ID chatId) {
+    if (chatId is ChatID) return chatId == getId();
+    if (chatId is SupergroupID || chatId is ChannelID) {
+      return chatId == getChannelId();
+    }
+    return false;
+  }
+}
+
+/// Extension on `User` to create ID of the chat
+extension GetUserChatID on User {
+  /// Returns the `ChatID` of the chat.
+  ChatID getId() {
+    return ChatID(id);
+  }
+
+  /// Gets the chat's `ChannelID` from the username
+  ID? getChannelId() {
+    if (username != null) return ChannelID(username!);
+    return null;
+  }
+
+  /// Returns true if the [chatId] passed matches the current chat's ID.
+  bool isTheSameChat(ID chatId) {
+    if (chatId is ChatID) return chatId == getId();
+    if (chatId is SupergroupID || chatId is ChannelID) {
+      return chatId == getChannelId();
+    }
+    return false;
+  }
+}

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -24,6 +24,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:math';
+import 'dart:mirrors';
 import 'package:dio/dio.dart';
 import 'package:televerse/telegram.dart';
 import 'package:televerse/televerse.dart';
@@ -60,6 +61,7 @@ part 'src/televerse/builders/message_content_generator.dart';
 
 /// Extras
 part 'src/televerse/extras/tg_exceptions.dart';
+part 'src/televerse/models/scope_options.dart';
 
 /// The main class of the library.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.2!
-version: 1.15.9
+version: 1.15.10
 homepage: https://github.com/HeySreelal/televerse
 topics:
   - telegram

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - bot-framework
 
 environment:
-  sdk: ">=2.17.7 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   dio: ^5.4.0


### PR DESCRIPTION
# 1.15.10

- Added `Bot.fromAPI` constructor for creating Bot instance from `RawAPI` instance.
- `Bot.command`, `Bot.text`, `Bot.hears`, and many more methods now listens to all Message types (Message, Channel Posts, and edited messages of both)
- ⚠️ Added `chatId` parameter to `Bot.shippingQuery` and `Bot.preCheckoutQuery`.
- Refactored code for quality and better readability and added docs.
- Added `ScopeOptions` class that can contain additional info for handler scope.
- `ScopeOptions.forked` to create forked handlers. Forked handlers are run without conditions.
- `ScopeOptions.customPredicate` can be used to set a middleware to check if the update should be processed or skipped.
- Migrated to `Dart 3.0.0`
- `Bot.removeScope` can be used to remove already set handlers.
- Accepts `ScopeOption` on both menus as well.