### PR TITLE
v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.17.1
+
+- ‼️ Strict typing for `ctx.editMessageMedia` and `ctx.editMessageReplyMarkup`
+- Fix: `ChatID` constuctor accepted `dynamic`
+
 # 1.17.0
 
 - 🤖 Bot API 7.4 (May 28, 2024)

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -1749,26 +1749,38 @@ class Context {
 
   /// Edit the message media
   /// Use this method to edit animation, audio, document, photo, or video messages.
-  Future<bool> editMessageMedia(
+  ///
+  /// Make sure to pass the type parameter for correct typing. If the message to be edited is an
+  /// inline message, the type parameter should be `bool`, otherwise `Message` should be passed.
+  ///
+  /// Since Televerse don't deal with `dynamic` types on the public interface, if you do not pass
+  /// type parameter, this method will throw a `TeleverseException`.
+  Future<MessageOrBool> editMessageMedia<MessageOrBool>(
     InputMedia media, {
     InlineKeyboardMarkup? replyMarkup,
   }) async {
+    if (MessageOrBool != Message && MessageOrBool != bool) {
+      throw TeleverseException.typeParameterRequired(
+        MessageOrBool,
+        [Message, bool],
+      );
+    }
+
     if (_isInline()) {
-      await api.editInlineMessageMedia(
+      return await api.editInlineMessageMedia(
         _inlineMsgId!,
         media,
         replyMarkup: replyMarkup,
-      );
+      ) as MessageOrBool;
     } else {
       _verifyInfo([_chatId, _msgId], APIMethod.editMessageMedia);
-      await api.editMessageMedia(
+      return await api.editMessageMedia(
         id,
         _msgId!,
         media,
         replyMarkup: replyMarkup,
-      );
+      ) as MessageOrBool;
     }
-    return true;
   }
 
   /// Edit the message reply markup

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -1761,6 +1761,7 @@ class Context {
   }) async {
     if (MessageOrBool != Message && MessageOrBool != bool) {
       throw TeleverseException.typeParameterRequired(
+        "editMessageMedia",
         MessageOrBool,
         [Message, bool],
       );
@@ -1785,23 +1786,29 @@ class Context {
 
   /// Edit the message reply markup
   /// Use this method to edit only the reply markup of messages.
-  Future<bool> editMessageReplyMarkup({
+  Future<MessageOrBool> editMessageReplyMarkup<MessageOrBool>({
     InlineKeyboardMarkup? replyMarkup,
   }) async {
+    if (MessageOrBool != Message && MessageOrBool != bool) {
+      throw TeleverseException.typeParameterRequired(
+        "editMessageReplyMarkup",
+        MessageOrBool,
+        [Message, bool],
+      );
+    }
     if (_isInline()) {
-      await api.editInlineMessageReplyMarkup(
+      return await api.editInlineMessageReplyMarkup(
         _inlineMsgId!,
         replyMarkup: replyMarkup,
-      );
+      ) as MessageOrBool;
     } else {
       _verifyInfo([_chatId, _msgId], APIMethod.editMessageReplyMarkup);
-      await api.editMessageReplyMarkup(
+      return await api.editMessageReplyMarkup(
         id,
         _msgId!,
         replyMarkup: replyMarkup,
-      );
+      ) as MessageOrBool;
     }
-    return true;
   }
 
   /// Answer inline query

--- a/lib/src/televerse/models/chat_id.dart
+++ b/lib/src/televerse/models/chat_id.dart
@@ -87,7 +87,7 @@ class ChatID extends ID {
   /// // Print the chat's title.
   /// print(chat.title);
   /// ```
-  const ChatID(super.id);
+  const ChatID(int super.id);
 
   /// The ID getter, returns the actual integer value
   @override

--- a/lib/src/televerse/models/televerse_exception.dart
+++ b/lib/src/televerse/models/televerse_exception.dart
@@ -94,4 +94,20 @@ class TeleverseException implements Exception {
       type: TeleverseExceptionType.timeoutException,
     );
   }
+
+  /// Exception thrown when the timeout exception occurs.
+  static TeleverseException typeParameterRequired(
+    Type type,
+    List<Type> expected,
+  ) {
+    return TeleverseException(
+      "Type Parameter Required.",
+      description:
+          "Televerse is a strictly typed library and does not allows usage of dynamic types. This exception is thrown either\n"
+          "   1. when you do not mention type parameter when it is required\n"
+          "   2. when you passed the type [$type] where types [${expected.join(', ')}] are expected.\n\n"
+          "If you are using the `Context.editMessageMedia` method, try `ctx.editMessageMedia<bool>` for inline messages or `editMessageMedia<Message>` otherwise.",
+      type: TeleverseExceptionType.invalidParameter,
+    );
+  }
 }

--- a/lib/src/televerse/models/televerse_exception.dart
+++ b/lib/src/televerse/models/televerse_exception.dart
@@ -97,6 +97,7 @@ class TeleverseException implements Exception {
 
   /// Exception thrown when the timeout exception occurs.
   static TeleverseException typeParameterRequired(
+    String method,
     Type type,
     List<Type> expected,
   ) {
@@ -104,9 +105,9 @@ class TeleverseException implements Exception {
       "Type Parameter Required.",
       description:
           "Televerse is a strictly typed library and does not allows usage of dynamic types. This exception is thrown either\n"
-          "   1. when you do not mention type parameter when it is required\n"
-          "   2. when you passed the type [$type] where types [${expected.join(', ')}] are expected.\n\n"
-          "If you are using the `Context.editMessageMedia` method, try `ctx.editMessageMedia<bool>` for inline messages or `editMessageMedia<Message>` otherwise.",
+          "   1. when you do not mention type parameter when it is required or\n"
+          "   2. when you've passed the type [$type] where types [${expected.join(', ')}] are expected.\n\n"
+          "If you are using the `Context.$method` method, try `ctx.$method<bool>(...)` for inline messages or `ctx.$method<Message>(...)` otherwise.",
       type: TeleverseExceptionType.invalidParameter,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.3!
-version: 1.17.0
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.4!
+version: 1.17.1
 homepage: https://github.com/HeySreelal/televerse
 topics:
   - telegram


### PR DESCRIPTION
# 1.17.1

- ‼️ Strict typing for `ctx.editMessageMedia` and `ctx.editMessageReplyMarkup`
- Fix: `ChatID` constuctor accepted `dynamic`
