### PR TITLE
Match commands from captions and fix in UserShared 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.17.2
 
 - Added `considerCaption` parameter in `Bot.command` mehtod to match commands in the caption of video/photo messages.
+- 🐞 Fixed: JSON parsing bug in `UsersShared` causing the `users` field to be null and resulting in crashes.
 
 # 1.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.17.2
+
+- Added `considerCaption` parameter in `Bot.command` mehtod to match commands in the caption of video/photo messages.
+
 # 1.17.1
 
 - ‼️ Strict typing for `ctx.editMessageMedia` and `ctx.editMessageReplyMarkup`

--- a/lib/src/telegram/models/users_shared.dart
+++ b/lib/src/telegram/models/users_shared.dart
@@ -20,7 +20,7 @@ class UsersShared {
   factory UsersShared.fromJson(Map<String, dynamic> json) {
     return UsersShared(
       requestId: json['request_id']!,
-      users: (json['user_ids'] as List<dynamic>)
+      users: (json['users'] as List<dynamic>)
           .map((e) => SharedUser.fromJson(e))
           .toList(),
     );
@@ -30,7 +30,7 @@ class UsersShared {
   Map<String, dynamic> toJson() {
     return {
       'request_id': requestId,
-      'user_ids': users.map((user) => user.toJson()).toList(),
+      'users': users.map((user) => user.toJson()).toList(),
     };
   }
 }

--- a/lib/src/televerse/bot.dart
+++ b/lib/src/televerse/bot.dart
@@ -473,6 +473,7 @@ class Bot {
     Pattern command,
     Handler callback, {
     ScopeOptions? options,
+    bool considerCaption = false,
   }) {
     if (initialized) {
       final scope = HandlerScope(
@@ -481,12 +482,18 @@ class Bot {
         handler: callback,
         types: UpdateType.messages(),
         predicate: (ctx) {
-          if (ctx.msg?.text == null) return false;
+          String? text;
+          if (considerCaption) {
+            text = ctx.msg?.caption;
+          }
+          text ??= ctx.msg?.text;
+
+          if (text == null) return false;
           if (command is RegExp) {
-            return command.hasMatch(ctx.msg?.text ?? "");
+            return command.hasMatch(text);
           } else if (command is String) {
-            final firstTerm = ctx.msg?.text!.split(' ').first;
-            final suffix = me.username != null ? '@${me.username}' : '';
+            final firstTerm = text.split(' ').first;
+            final suffix = '@${me.username}';
             return firstTerm == '/$command' || firstTerm == '/$command$suffix';
           }
           return false;
@@ -503,6 +510,7 @@ class Bot {
           params: [command, callback],
           namedParams: {
             #options: options,
+            #considerCaption: considerCaption,
           },
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.4!
-version: 1.17.1
+version: 1.17.2
 homepage: https://github.com/HeySreelal/televerse
 topics:
   - telegram


### PR DESCRIPTION
# 1.17.2

- Added `considerCaption` parameter in `Bot.command` mehtod to match commands in the caption of video/photo messages.
- 🐞 Fixed: JSON parsing bug in `UsersShared` causing the `users` field to be null and resulting in crashes.
