### PR TITLE
tidy up some logic, fix wrong handler order

### DIFF
--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -123,7 +123,7 @@ class Bot<CTX extends Context> {
   }
 
   /// The fetcher - used to fetch updates from the Telegram servers.
-  late final Fetcher<CTX> fetcher;
+  final Fetcher<CTX> fetcher;
 
   /// The bot token.
   final String token;

--- a/lib/src/televerse/models/handler_scope.dart
+++ b/lib/src/televerse/models/handler_scope.dart
@@ -44,9 +44,6 @@ class HandlerScope<CTX extends Context> {
     this.options,
   }) : assert(handler != null || isConversation);
 
-  /// Whether the scope is forked or not.
-  bool get forked => options?.forked ?? false;
-
   /// Name of the scope
   String? get name => options?.name;
 

--- a/lib/src/televerse/models/handler_scope.dart
+++ b/lib/src/televerse/models/handler_scope.dart
@@ -52,4 +52,7 @@ class HandlerScope<CTX extends Context> {
 
   /// Whether the scope has a custom predicate
   bool get hasCustomPredicate => options?.customPredicate != null;
+
+  @override
+  String toString() => options?.name ?? 'Unnamed';
 }

--- a/lib/src/televerse/models/scope_options.dart
+++ b/lib/src/televerse/models/scope_options.dart
@@ -7,15 +7,6 @@ class ScopeOptions<CTX extends Context> {
   /// This can be used to remove a Handler later on your code.
   final String? name;
 
-  /// Whether the scope is forked.
-  ///
-  /// By default fork is set to `false` that is once a matching scope is found
-  /// the processor only executes that particular scope and skips all the rest.
-  ///
-  /// When fork is set to `true` the successive Handler Scope is also considered
-  /// and executed if it satisfies the predicate.
-  final bool forked;
-
   /// Custom Predicate Method
   ///
   /// Often some handlers require restricted access, like admin controls or bans.
@@ -28,9 +19,6 @@ class ScopeOptions<CTX extends Context> {
   ///
   /// This approach keeps your code clean and avoids repetitive permission checks.
   ///
-  /// Note: [forked] overrides this. That is even if [customPredicate] may evaluate
-  /// to `false` if [forked] is true the handler is executed.
-  ///
   /// If by any reason, this method threw any exception, it'll be caught in the passed `Bot.onError` if set.
   /// Otherwise, treated as `false` evaluation and skips the current handler.
   final FutureOr<bool> Function(CTX ctx)? customPredicate;
@@ -38,29 +26,16 @@ class ScopeOptions<CTX extends Context> {
   /// Constructs a `ScopeOption`.
   ///
   /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
-  ///
-  /// - [forked] - A flag used to determine whether the succeeding handler should also be executed
   const ScopeOptions({
-    this.forked = false,
     this.name,
     this.customPredicate,
   });
-
-  /// Constructs a `ScopeOption` that is forked. This scope will allow the processing of subsequent handler scope as well.
-  ///
-  /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
-  /// - [customPredicate] - Middleware to check if the update should be processed or skipped.
-  const ScopeOptions.forked({
-    this.name,
-    this.customPredicate,
-  }) : forked = true;
 
   /// Creates a copy of this [ScopeOptions] object with potentially modified properties.
 
   /// Provides options to override the following properties:
   ///
   /// * [name]: The name of the scope. If not provided, it will be inherited from the original object.
-  /// * [forked]: Whether the scope is forked. If not provided, it will be inherited from the original object.
   /// * [customPredicate]: A custom predicate function that determines when updates within the scope are processed.
   ///   If not provided, it will be inherited from the original object.
   ///
@@ -70,12 +45,10 @@ class ScopeOptions<CTX extends Context> {
   /// Returns a new instance of [ScopeOptions] with the updated properties.
   ScopeOptions<CTX> copyWith({
     String? name,
-    bool? forked,
     FutureOr<bool> Function(CTX ctx)? customPredicate,
   }) {
     return ScopeOptions<CTX>(
       name: name ?? this.name,
-      forked: forked ?? this.forked,
       customPredicate: customPredicate ?? this.customPredicate,
     );
   }
@@ -84,20 +57,17 @@ class ScopeOptions<CTX extends Context> {
   static ScopeOptions<CTX> _createOrCopy<CTX extends Context>(
     ScopeOptions<CTX>? options, {
     String? name,
-    bool? forked,
     FutureOr<bool> Function(CTX ctx)? customPredicate,
   }) {
     if (options != null) {
       return options.copyWith(
         name: name,
-        forked: forked,
         customPredicate: customPredicate,
       );
     }
 
     return ScopeOptions<CTX>(
       name: name,
-      forked: forked ?? false,
       customPredicate: customPredicate,
     );
   }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -106,23 +106,6 @@ enum _GetMeStatus {
   ;
 }
 
-/// Represents a pending method call
-class _PendingCall {
-  final Function fn;
-  final List<dynamic> params;
-  final Map<Symbol, dynamic> namedParams;
-
-  const _PendingCall({
-    required this.fn,
-    required this.params,
-    this.namedParams = const <Symbol, dynamic>{},
-  });
-
-  void call() {
-    Function.apply(fn, params, namedParams);
-  }
-}
-
 /// Extension on `Chat` to create ID of the chat
 extension GetChatID on Chat {
   /// Returns the `ChatID` of the chat.


### PR DESCRIPTION
This should fix #104, needs further testing.

What I've done:
- Moved the bot initialization to the bot.start function
- Made the fetcher initialize inside of the constructor, where it belongs
- Removed pending calls
- Removed forked handlers 
- Removed some late variable and made it into a nullable one
- Removed the now unused methods