### PR TITLE
Televerse v1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 1.22.0
+
+- 🤖 Bot API 7.7
+- Added the `RefundedPayment` class and the `Message.refundedPayment` property
+- Initalizes fetcher on the constructor
+- Moved the inital `getMe` call to be made from hte `Bot.start` method
+- Remoed Pending Calls (which caused some troubles in the handler scopes order)
+- Removed forked handlers, - well who knew it was there?
+- All thanks to [@im-trisha](https://github.com/im-trisha)
+- Fixed an issue that caused Bot to listen to the official Bot API even though
+  created with `Bot.local` -
+  [#275](https://github.com/HeySreelal/televerse/issues/275) (Thanks to
+  [@devdocs](https://github.com/devsdocs) for reporting)
+- Fixed [#274](https://github.com/HeySreelal/televerse/issues/274)
+- Fix [#277](https://github.com/HeySreelal/televerse/issues/277)
+- Fix [#104](https://github.com/HeySreelal/televerse/issues/104)
+- Fixed more typing issues.
+- `Bot.start` now accepts zero parameters.
+- Added `Context.maybeId` a nullable ID instance
+
 # 1.21.1
 
 - `Webhook` now accepts a `shouldSetWebhook` flag which indicates whether the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Pub Version](https://img.shields.io/pub/v/televerse?color=blue&logo=blue)](https://pub.dev/packages/televerse)
 ![GitHub](https://img.shields.io/github/license/HeySreelal/televerse?color=green)
-![](https://shields.io/badge/Latest-Bot%20API%207.6-blue)
+![](https://shields.io/badge/Latest-Bot%20API%207.7-blue)
 
 <a href="https://telegram.me/TeleverseDart">
     <img src="https://img.shields.io/badge/Telegram%2F@TeleverseDart-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white"/>
@@ -13,7 +13,7 @@
 
 ---
 
-🤖 `Bot API version: Bot API 7.6 (July 1, 2024)`
+🤖 `Bot API version: Bot API 7.7 (July 7, 2024)`
 
 Televerse is a powerful, easy-to-use, and highly customizable Telegram bot
 framework built with Dart programming language. It provides a complete and
@@ -23,15 +23,13 @@ public interface, making it easy for developers to write strictly typed code.
 
 ## 🔥 What's latest?
 
-### 🤖 Bot API 7.6
+### 🤖 Bot API 7.7
 
-(🗓️ July 1, 2024)
+(🗓️ July 8, 2024)
 
-In a nutshell, the updates include support for the new Paid Media messages.
-Brings the new `sendPaidMedia` message to send paid media messages. Introduces
-`TransactionPartnerTelegramAds`, new field in `ChatFullInfo`, and more.
+Simply, this change brings support for Refunds of Payment.
 
-Checkout [changelog](https://core.telegram.org/bots/api#july-1-2024) for more
+Checkout [changelog](https://core.telegram.org/bots/api#july-7-2024) for more
 details! 🚀
 
 ### 🎉 Support for Custom Contexts!
@@ -49,16 +47,6 @@ With the new `Bot.contextBuilder` method, you can define specialized context
 constructors to create context objects with personalized behaviors and
 capabilities. This update allows you to tailor your bot's responses, handle
 complex workflows, and integrate additional features seamlessly.
-
-### Introducing Middleware & Transformer support!
-
-(🗓️ June 22, 2024)
-
-You can now use the `Bot.use` method to attach middlewares to your bot. These
-middlewares will be processed before your main handler runs, allowing you to
-pre-process or even decide whether to execute the main handler. Additionally,
-using a `Transformer` lets you directly modify the request payload, reducing
-redundant code and simplifying your coding experience.
 
 <hr>
 

--- a/lib/src/telegram/models/abstractions.dart
+++ b/lib/src/telegram/models/abstractions.dart
@@ -20,3 +20,21 @@ abstract class WithID {
 
 /// Null filter function.
 bool _nullFilter(String _, dynamic value) => value == null;
+
+/// A helper method to parse a nested object from JSON.
+T? _parseJson<T>(
+  Map<String, dynamic>? json,
+  T Function(Map<String, dynamic>) fromJson,
+) {
+  if (json == null) return null;
+  return fromJson(json);
+}
+
+/// A helper method to parse a list of nested objects from JSON.
+List<T>? _parseList<T>(
+  List<dynamic>? json,
+  T Function(Map<String, dynamic>) fromJson,
+) {
+  if (json == null) return null;
+  return (json).map((e) => fromJson(e as Map<String, dynamic>)).toList();
+}

--- a/lib/src/telegram/models/abstracts/passport_element_error.dart
+++ b/lib/src/telegram/models/abstracts/passport_element_error.dart
@@ -18,7 +18,7 @@ abstract class PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
     }..removeWhere(_nullFilter);
   }
 }

--- a/lib/src/telegram/models/inline_query_result_gif.dart
+++ b/lib/src/telegram/models/inline_query_result_gif.dart
@@ -71,7 +71,7 @@ class InlineQueryResultGif implements InlineQueryResult {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'id': id,
       'gif_url': gifUrl,
       'gif_width': gifWidth,

--- a/lib/src/telegram/models/input_paid_media_photo.dart
+++ b/lib/src/telegram/models/input_paid_media_photo.dart
@@ -21,7 +21,7 @@ class InputPaidMediaPhoto implements InputPaidMedia {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'media': media.getValue('media'),
     };
   }

--- a/lib/src/telegram/models/input_paid_media_video.dart
+++ b/lib/src/telegram/models/input_paid_media_video.dart
@@ -41,7 +41,7 @@ class InputPaidMediaVideo implements InputPaidMedia {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'media': media.getValue('media'),
       'thumbnail': thumbnail?.getValue('thumbnail'),
       'width': width,

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -358,192 +358,179 @@ class Message implements MaybeInaccessibleMessage, WithUser {
   factory Message.fromJson(Map<String, dynamic> json) {
     return Message(
       messageId: json['message_id'],
-      from: json['from'] == null ? null : User.fromJson(json['from']),
-      senderChat: json['sender_chat'] == null
-          ? null
-          : Chat.fromJson(json['sender_chat']),
+      from: _parseJson<User>(json['from'], User.fromJson),
+      senderChat: _parseJson<Chat>(json['sender_chat'], Chat.fromJson),
       date: json['date'],
       chat: Chat.fromJson(json['chat']),
-      replyToMessage: json['reply_to_message'] == null
-          ? null
-          : Message.fromJson(json['reply_to_message']),
-      viaBot: json['via_bot'] == null ? null : User.fromJson(json['via_bot']),
+      replyToMessage:
+          _parseJson<Message>(json['reply_to_message'], Message.fromJson),
+      viaBot: _parseJson<User>(json['via_bot'], User.fromJson),
       editDate: json['edit_date'],
       mediaGroupId: json['media_group_id'],
       authorSignature: json['author_signature'],
       text: json['text'],
-      entities: (json['entities'] as List<dynamic>?)
-          ?.map((e) => MessageEntity.fromJson(e))
-          .toList(),
-      animation: json['animation'] == null
-          ? null
-          : Animation.fromJson(json['animation']),
-      audio: json['audio'] == null ? null : Audio.fromJson(json['audio']),
-      document:
-          json['document'] == null ? null : Document.fromJson(json['document']),
-      photo: (json['photo'] as List<dynamic>?)
-          ?.map((e) => PhotoSize.fromJson(e))
-          .toList(),
-      sticker:
-          json['sticker'] == null ? null : Sticker.fromJson(json['sticker']),
-      video: json['video'] == null ? null : Video.fromJson(json['video']),
-      videoNote: json['video_note'] == null
-          ? null
-          : VideoNote.fromJson(json['video_note']),
-      voice: json['voice'] == null ? null : Voice.fromJson(json['voice']),
+      entities:
+          _parseList<MessageEntity>(json['entities'], MessageEntity.fromJson),
+      animation: _parseJson<Animation>(json['animation'], Animation.fromJson),
+      audio: _parseJson<Audio>(json['audio'], Audio.fromJson),
+      document: _parseJson<Document>(json['document'], Document.fromJson),
+      photo: _parseList<PhotoSize>(json['photo'], PhotoSize.fromJson),
+      sticker: _parseJson<Sticker>(json['sticker'], Sticker.fromJson),
+      video: _parseJson<Video>(json['video'], Video.fromJson),
+      videoNote: _parseJson<VideoNote>(json['video_note'], VideoNote.fromJson),
+      voice: _parseJson<Voice>(json['voice'], Voice.fromJson),
       caption: json['caption'],
-      captionEntities: (json['caption_entities'] as List<dynamic>?)
-          ?.map((e) => MessageEntity.fromJson(e))
-          .toList(),
-      contact:
-          json['contact'] == null ? null : Contact.fromJson(json['contact']),
-      dice: json['dice'] == null ? null : Dice.fromJson(json['dice']),
-      game: json['game'] == null ? null : Game.fromJson(json['game']),
-      poll: json['poll'] == null ? null : Poll.fromJson(json['poll']),
-      venue: json['venue'] == null ? null : Venue.fromJson(json['venue']),
-      location:
-          json['location'] == null ? null : Location.fromJson(json['location']),
-      newChatMembers: (json['new_chat_members'] as List<dynamic>?)
-          ?.map((e) => User.fromJson(e))
-          .toList(),
-      leftChatMember: json['left_chat_member'] == null
-          ? null
-          : User.fromJson(json['left_chat_member']),
+      captionEntities: _parseList<MessageEntity>(
+        json['caption_entities'],
+        MessageEntity.fromJson,
+      ),
+      contact: _parseJson<Contact>(json['contact'], Contact.fromJson),
+      dice: _parseJson<Dice>(json['dice'], Dice.fromJson),
+      game: _parseJson<Game>(json['game'], Game.fromJson),
+      poll: _parseJson<Poll>(json['poll'], Poll.fromJson),
+      venue: _parseJson<Venue>(json['venue'], Venue.fromJson),
+      location: _parseJson<Location>(json['location'], Location.fromJson),
+      newChatMembers: _parseList<User>(json['new_chat_members'], User.fromJson),
+      leftChatMember: _parseJson<User>(json['left_chat_member'], User.fromJson),
       newChatTitle: json['new_chat_title'],
-      newChatPhoto: (json['new_chat_photo'] as List<dynamic>?)
-          ?.map((e) => PhotoSize.fromJson(e))
-          .toList(),
+      newChatPhoto:
+          _parseList<PhotoSize>(json['new_chat_photo'], PhotoSize.fromJson),
       deleteChatPhoto: json['delete_chat_photo'],
       groupChatCreated: json['group_chat_created'],
       supergroupChatCreated: json['supergroup_chat_created'],
       channelChatCreated: json['channel_chat_created'],
-      messageAutoDeleteTimerChanged:
-          json['message_auto_delete_timer_changed'] == null
-              ? null
-              : MessageAutoDeleteTimerChanged.fromJson(
-                  json['message_auto_delete_timer_changed'],
-                ),
+      messageAutoDeleteTimerChanged: _parseJson<MessageAutoDeleteTimerChanged>(
+        json['message_auto_delete_timer_changed'],
+        MessageAutoDeleteTimerChanged.fromJson,
+      ),
       migrateToChatId: json['migrate_to_chat_id'],
       migrateFromChatId: json['migrate_from_chat_id'],
-      pinnedMessage: json['pinned_message'] == null
-          ? null
-          : Message.fromJson(json['pinned_message']),
-      invoice:
-          json['invoice'] == null ? null : Invoice.fromJson(json['invoice']),
-      successfulPayment: json['successful_payment'] == null
-          ? null
-          : SuccessfulPayment.fromJson(json['successful_payment']),
+      pinnedMessage:
+          _parseJson<Message>(json['pinned_message'], Message.fromJson),
+      invoice: _parseJson<Invoice>(json['invoice'], Invoice.fromJson),
+      successfulPayment: _parseJson<SuccessfulPayment>(
+        json['successful_payment'],
+        SuccessfulPayment.fromJson,
+      ),
       connectedWebsite: json['connected_website'],
-      passportData: json['passport_data'] == null
-          ? null
-          : PassportData.fromJson(json['passport_data']),
-      proximityAlertTriggered: json['proximity_alert_triggered'] == null
-          ? null
-          : ProximityAlertTriggered.fromJson(json['proximity_alert_triggered']),
-      replyMarkup: json['reply_markup'] == null
-          ? null
-          : InlineKeyboardMarkup.fromJson(json['reply_markup']),
+      passportData: _parseJson<PassportData>(
+        json['passport_data'],
+        PassportData.fromJson,
+      ),
+      proximityAlertTriggered: _parseJson<ProximityAlertTriggered>(
+        json['proximity_alert_triggered'],
+        ProximityAlertTriggered.fromJson,
+      ),
+      replyMarkup: _parseJson<InlineKeyboardMarkup>(
+        json['reply_markup'],
+        InlineKeyboardMarkup.fromJson,
+      ),
       isAutomaticForward: json['is_automatic_forward'],
-      webAppData: json['web_app_data'] == null
-          ? null
-          : WebAppData.fromJson(json['web_app_data']),
-      videoChatEnded: json['video_chat_ended'] == null
-          ? null
-          : VideoChatEnded.fromJson(json['video_chat_ended']),
-      videoChatStarted: json['video_chat_started'] == null
-          ? null
-          : VideoChatStarted.fromJson(json['video_chat_started']),
-      videoChatParticipantsInvited:
-          json['video_chat_participants_invited'] == null
-              ? null
-              : VideoChatParticipantsInvited.fromJson(
-                  json['video_chat_participants_invited'],
-                ),
-      videoChatScheduled: json['video_chat_scheduled'] == null
-          ? null
-          : VideoChatScheduled.fromJson(json['video_chat_scheduled']),
-      forumTopicClosed: json['forum_topic_closed'] == null
-          ? null
-          : ForumTopicClosed.fromJson(json['forum_topic_closed']),
-      forumTopicCreated: json['forum_topic_created'] == null
-          ? null
-          : ForumTopicCreated.fromJson(json['forum_topic_created']),
-      forumTopicReopened: json['forum_topic_reopened'] == null
-          ? null
-          : ForumTopicReopened.fromJson(json['forum_topic_reopened']),
+      webAppData:
+          _parseJson<WebAppData>(json['web_app_data'], WebAppData.fromJson),
+      videoChatEnded: _parseJson<VideoChatEnded>(
+        json['video_chat_ended'],
+        VideoChatEnded.fromJson,
+      ),
+      videoChatStarted: _parseJson<VideoChatStarted>(
+        json['video_chat_started'],
+        VideoChatStarted.fromJson,
+      ),
+      videoChatParticipantsInvited: _parseJson<VideoChatParticipantsInvited>(
+        json['video_chat_participants_invited'],
+        VideoChatParticipantsInvited.fromJson,
+      ),
+      videoChatScheduled: _parseJson<VideoChatScheduled>(
+        json['video_chat_scheduled'],
+        VideoChatScheduled.fromJson,
+      ),
+      forumTopicClosed: _parseJson<ForumTopicClosed>(
+        json['forum_topic_closed'],
+        ForumTopicClosed.fromJson,
+      ),
+      forumTopicCreated: _parseJson<ForumTopicCreated>(
+        json['forum_topic_created'],
+        ForumTopicCreated.fromJson,
+      ),
+      forumTopicReopened: _parseJson<ForumTopicReopened>(
+        json['forum_topic_reopened'],
+        ForumTopicReopened.fromJson,
+      ),
       hasProtectedContent: json['has_protected_content'],
       isTopicMessage: json['is_topic_message'],
       messageThreadId: json['message_thread_id'],
-      usersShared: json['users_shared'] == null
-          ? null
-          : UsersShared.fromJson(json['user_shared']),
-      chatShared: json['chat_shared'] == null
-          ? null
-          : ChatShared.fromJson(json['chat_shared']),
+      usersShared:
+          _parseJson<UsersShared>(json['users_shared'], UsersShared.fromJson),
+      chatShared:
+          _parseJson<ChatShared>(json['chat_shared'], ChatShared.fromJson),
       hasMediaSpoiler: json['has_media_spoiler'],
-      forumTopicEdited: json['forum_topic_edited'] == null
-          ? null
-          : ForumTopicEdited.fromJson(json['forum_topic_edited']),
-      generalForumTopicHidden: json['general_forum_topic_hidden'] == null
-          ? null
-          : GeneralForumTopicHidden.fromJson(
-              json['general_forum_topic_hidden'],
-            ),
-      generalForumTopicUnhidden: json['general_forum_topic_unhidden'] == null
-          ? null
-          : GeneralForumTopicUnhidden.fromJson(
-              json['general_forum_topic_unhidden'],
-            ),
-      writeAccessAllowed: json['write_access_allowed'] == null
-          ? null
-          : WriteAccessAllowed.fromJson(json['write_access_allowed']),
-      story: json['story'] == null ? null : Story.fromJson(json['story']),
-      externalReply: json['external_reply'] == null
-          ? null
-          : ExternalReplyInfo.fromJson(json['external_reply']),
-      quote: json['quote'] == null ? null : TextQuote.fromJson(json['quote']),
-      linkPreviewOptions: json['link_preview_options'] == null
-          ? null
-          : LinkPreviewOptions.fromJson(json['link_preview_options']),
-      giveaway:
-          json['giveaway'] == null ? null : Giveaway.fromJson(json['giveaway']),
-      giveawayCreated: json['giveaway_created'] == null
-          ? null
-          : GiveawayCreated.fromJson(json['giveaway_created']),
-      giveawayWinners: json['giveaway_winners'] == null
-          ? null
-          : GiveawayWinners.fromJson(json['giveaway_winners']),
-      giveawayCompleted: json['giveaway_completed'] == null
-          ? null
-          : GiveawayCompleted.fromJson(json['giveaway_completed']),
-      forwardOrigin: json['forward_origin'] == null
-          ? null
-          : MessageOrigin.fromJson(json['forward_origin']),
-      boostAdded: json["boost_added"] != null
-          ? ChatBoostAdded.fromJson(
-              json["boost_added"],
-            )
-          : null,
+      forumTopicEdited: _parseJson<ForumTopicEdited>(
+        json['forum_topic_edited'],
+        ForumTopicEdited.fromJson,
+      ),
+      generalForumTopicHidden: _parseJson<GeneralForumTopicHidden>(
+        json['general_forum_topic_hidden'],
+        GeneralForumTopicHidden.fromJson,
+      ),
+      generalForumTopicUnhidden: _parseJson<GeneralForumTopicUnhidden>(
+        json['general_forum_topic_unhidden'],
+        GeneralForumTopicUnhidden.fromJson,
+      ),
+      writeAccessAllowed: _parseJson<WriteAccessAllowed>(
+        json['write_access_allowed'],
+        WriteAccessAllowed.fromJson,
+      ),
+      story: _parseJson<Story>(json['story'], Story.fromJson),
+      externalReply: _parseJson<ExternalReplyInfo>(
+        json['external_reply'],
+        ExternalReplyInfo.fromJson,
+      ),
+      quote: _parseJson<TextQuote>(json['quote'], TextQuote.fromJson),
+      linkPreviewOptions: _parseJson<LinkPreviewOptions>(
+        json['link_preview_options'],
+        LinkPreviewOptions.fromJson,
+      ),
+      giveaway: _parseJson<Giveaway>(json['giveaway'], Giveaway.fromJson),
+      giveawayCreated: _parseJson<GiveawayCreated>(
+        json['giveaway_created'],
+        GiveawayCreated.fromJson,
+      ),
+      giveawayWinners: _parseJson<GiveawayWinners>(
+        json['giveaway_winners'],
+        GiveawayWinners.fromJson,
+      ),
+      giveawayCompleted: _parseJson<GiveawayCompleted>(
+        json['giveaway_completed'],
+        GiveawayCompleted.fromJson,
+      ),
+      forwardOrigin: _parseJson<MessageOrigin>(
+        json['forward_origin'],
+        MessageOrigin.fromJson,
+      ),
+      boostAdded: _parseJson<ChatBoostAdded>(
+        json['boost_added'],
+        ChatBoostAdded.fromJson,
+      ),
       senderBoostCount: json["sender_boost_count"],
-      replyToStory: json["reply_to_story"] != null
-          ? Story.fromJson(json["reply_to_story"])
-          : null,
+      replyToStory: _parseJson<Story>(json["reply_to_story"], Story.fromJson),
       businessConnectionId: json["business_connection_id"],
-      senderBusinessBot: json["sender_business_bot"] != null
-          ? User.fromJson(json["sender_business_bot"])
-          : null,
+      senderBusinessBot:
+          _parseJson<User>(json["sender_business_bot"], User.fromJson),
       isFromOffline: json["is_from_offline"],
-      chatBackgroundSet: json["chat_background_set"] != null
-          ? ChatBackground.fromJson(json["chat_background_set"])
-          : null,
+      chatBackgroundSet: _parseJson<ChatBackground>(
+        json["chat_background_set"],
+        ChatBackground.fromJson,
+      ),
       effectId: json["effect_id"],
       showCaptionAboveMedia: json["show_caption_above_media"],
-      paidMedia: json['paid_media'] != null
-          ? PaidMediaInfo.fromJson(json['paid_media'])
-          : null,
-      refundedPayment: json['refunded_payment'] != null
-          ? RefundedPayment.fromJson(json['refunded_payment'])
-          : null,
+      paidMedia: _parseJson<PaidMediaInfo>(
+        json['paid_media'],
+        PaidMediaInfo.fromJson,
+      ),
+      refundedPayment: _parseJson<RefundedPayment>(
+        json['refunded_payment'],
+        RefundedPayment.fromJson,
+      ),
     );
   }
 

--- a/lib/src/telegram/models/message.dart
+++ b/lib/src/telegram/models/message.dart
@@ -262,6 +262,9 @@ class Message implements MaybeInaccessibleMessage, WithUser {
   /// Optional. Message contains paid media; information about the paid media
   final PaidMediaInfo? paidMedia;
 
+  /// Optional. Message is a service message about a refunded payment, information about the payment. More about payments »
+  final RefundedPayment? refundedPayment;
+
   /// Creates a Message object.
   const Message({
     this.from,
@@ -348,6 +351,7 @@ class Message implements MaybeInaccessibleMessage, WithUser {
     this.effectId,
     this.showCaptionAboveMedia,
     this.paidMedia,
+    this.refundedPayment,
   });
 
   /// Creates a [Message] object from json map.
@@ -537,6 +541,9 @@ class Message implements MaybeInaccessibleMessage, WithUser {
       paidMedia: json['paid_media'] != null
           ? PaidMediaInfo.fromJson(json['paid_media'])
           : null,
+      refundedPayment: json['refunded_payment'] != null
+          ? RefundedPayment.fromJson(json['refunded_payment'])
+          : null,
     );
   }
 
@@ -629,6 +636,7 @@ class Message implements MaybeInaccessibleMessage, WithUser {
       'effect_id': effectId,
       'show_caption_above_media': showCaptionAboveMedia,
       'paid_media': paidMedia?.toJson(),
+      'refunded_payment': refundedPayment?.toJson(),
     }..removeWhere(_nullFilter);
   }
 

--- a/lib/src/telegram/models/models.dart
+++ b/lib/src/telegram/models/models.dart
@@ -265,3 +265,6 @@ part 'abstracts/input_paid_media.dart';
 part 'input_paid_media_photo.dart';
 part 'input_paid_media_video.dart';
 part 'transaction_partner_telegram_ads.dart';
+
+// Bot API 7.7
+part 'refunded_payment.dart';

--- a/lib/src/telegram/models/paid_media_photo.dart
+++ b/lib/src/telegram/models/paid_media_photo.dart
@@ -26,7 +26,7 @@ class PaidMediaPhoto extends PaidMedia {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'photo': photo.map((item) => item.toJson()).toList(),
     };
   }

--- a/lib/src/telegram/models/paid_media_preview.dart
+++ b/lib/src/telegram/models/paid_media_preview.dart
@@ -34,7 +34,7 @@ class PaidMediaPreview extends PaidMedia {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'width': width,
       'height': height,
       'duration': duration,

--- a/lib/src/telegram/models/paid_media_video.dart
+++ b/lib/src/telegram/models/paid_media_video.dart
@@ -24,7 +24,7 @@ class PaidMediaVideo extends PaidMedia {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'video': video.toJson(),
     };
   }

--- a/lib/src/telegram/models/passport_element_error_data_field.dart
+++ b/lib/src/telegram/models/passport_element_error_data_field.dart
@@ -25,7 +25,7 @@ class PassportElementErrorDataField extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'field_name': fieldName,
       'data_hash': dataHash,

--- a/lib/src/telegram/models/passport_element_error_file.dart
+++ b/lib/src/telegram/models/passport_element_error_file.dart
@@ -21,7 +21,7 @@ class PassportElementErrorFile extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hash': fileHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_files.dart
+++ b/lib/src/telegram/models/passport_element_error_files.dart
@@ -21,7 +21,7 @@ class PassportElementErrorFiles extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hashes': fileHashes,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_front_side.dart
+++ b/lib/src/telegram/models/passport_element_error_front_side.dart
@@ -21,7 +21,7 @@ class PassportElementErrorFrontSide extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hash': fileHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_reverse_side.dart
+++ b/lib/src/telegram/models/passport_element_error_reverse_side.dart
@@ -21,7 +21,7 @@ class PassportElementErrorReverseSide extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hash': fileHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_selfie.dart
+++ b/lib/src/telegram/models/passport_element_error_selfie.dart
@@ -21,7 +21,7 @@ class PassportElementErrorSelfie extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hash': fileHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_translation_file.dart
+++ b/lib/src/telegram/models/passport_element_error_translation_file.dart
@@ -21,7 +21,7 @@ class PassportElementErrorTranslationFile extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hash': fileHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_translation_files.dart
+++ b/lib/src/telegram/models/passport_element_error_translation_files.dart
@@ -21,7 +21,7 @@ class PassportElementErrorTranslationFiles extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'file_hashes': fileHashes,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/passport_element_error_unspecified.dart
+++ b/lib/src/telegram/models/passport_element_error_unspecified.dart
@@ -21,7 +21,7 @@ class PassportElementErrorUnspecified extends PassportElementError {
   Map<String, dynamic> toJson() {
     return {
       'source': source,
-      'type': type,
+      'type': type.value,
       'message': message,
       'element_hash': elementHash,
     }..removeWhere(_nullFilter);

--- a/lib/src/telegram/models/refunded_payment.dart
+++ b/lib/src/telegram/models/refunded_payment.dart
@@ -1,0 +1,50 @@
+part of 'models.dart';
+
+/// This object contains basic information about a refunded payment.
+class RefundedPayment {
+  /// Three-letter ISO 4217 currency code, or “XTR” for payments in Telegram Stars. Currently, always “XTR”.
+  final String currency;
+
+  /// Total refunded price in the smallest units of the currency (integer, not float/double). For example, for a price of US$ 1.45, total_amount = 145.
+  final int totalAmount;
+
+  /// Bot-specified invoice payload.
+  final String invoicePayload;
+
+  /// Telegram payment identifier.
+  final String telegramPaymentChargeId;
+
+  /// Optional. Provider payment identifier.
+  final String? providerPaymentChargeId;
+
+  /// Constructs a [RefundedPayment] object.
+  const RefundedPayment({
+    required this.currency,
+    required this.totalAmount,
+    required this.invoicePayload,
+    required this.telegramPaymentChargeId,
+    this.providerPaymentChargeId,
+  });
+
+  /// Creates a [RefundedPayment] object from JSON.
+  factory RefundedPayment.fromJson(Map<String, dynamic> json) {
+    return RefundedPayment(
+      currency: json['currency'],
+      totalAmount: json['total_amount'],
+      invoicePayload: json['invoice_payload'],
+      telegramPaymentChargeId: json['telegram_payment_charge_id'],
+      providerPaymentChargeId: json['provider_payment_charge_id'],
+    );
+  }
+
+  /// Converts a [RefundedPayment] object to JSON.
+  Map<String, dynamic> toJson() {
+    return {
+      'currency': currency,
+      'total_amount': totalAmount,
+      'invoice_payload': invoicePayload,
+      'telegram_payment_charge_id': telegramPaymentChargeId,
+      'provider_payment_charge_id': providerPaymentChargeId,
+    }..removeWhere(_nullFilter);
+  }
+}

--- a/lib/src/telegram/models/transaction_partner_fragment.dart
+++ b/lib/src/telegram/models/transaction_partner_fragment.dart
@@ -26,7 +26,7 @@ class TransactionPartnerFragment extends TransactionPartner {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
       'withdrawal_state': withdrawalState?.toJson(),
     };
   }

--- a/lib/src/telegram/models/transaction_partner_other.dart
+++ b/lib/src/telegram/models/transaction_partner_other.dart
@@ -17,7 +17,7 @@ class TransactionPartnerOther extends TransactionPartner {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.value,
     };
   }
 }

--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -580,11 +580,9 @@ class Bot<CTX extends Context> {
     await _initializeBot();
 
     fetcher.onUpdate().listen(
-      _onUpdate,
-      onDone: () {
-        _onStop.call();
-      },
-    );
+          _onUpdate,
+          onDone: _onStop,
+        );
     try {
       fetcher.start();
     } catch (err, stack) {

--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -156,7 +156,6 @@ class Bot<CTX extends Context> {
         isLocal = baseURL != RawAPI.defaultBase,
         _loggerOptions = loggerOptions,
         _scheme = scheme,
-        _api = RawAPI(token, loggerOptions: loggerOptions, timeout: timeout),
         fetcher = fetcher ?? LongPolling<CTX>() {
     // Set the default error handler
     onError(_defaultErrorHandler);
@@ -239,7 +238,7 @@ class Bot<CTX extends Context> {
   /// Initializes the bot with common setup logic.
   Future<void> _initializeBot() async {
     // Create Fetcher and assign the RawAPI instance
-    fetcher.setApi(_api!);
+    fetcher.setApi(api);
 
     // Perform initial /getMe request
     try {

--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -573,12 +573,10 @@ class Bot<CTX extends Context> {
   /// use Update.fromJson(json) to convert the json to an update.
   void handleUpdate(Update update) => _onUpdate(update);
 
-  /// Start polling for updates.
+  /// Start polling or webhook listener for fetching updates.
   ///
-  /// This method starts polling for updates. It will automatically start the fetcher.
-  Future<void> start({
-    bool shouldSetWebhook = true,
-  }) async {
+  /// Note: This method must be awaited.
+  Future<void> start() async {
     await _initializeBot();
 
     fetcher.onUpdate().listen(

--- a/lib/src/televerse/bot/bot.dart
+++ b/lib/src/televerse/bot/bot.dart
@@ -123,7 +123,7 @@ class Bot<CTX extends Context> {
   }
 
   /// The fetcher - used to fetch updates from the Telegram servers.
-  late final Fetcher<CTX> fetcher;
+  final Fetcher<CTX> fetcher;
 
   /// The bot token.
   final String token;
@@ -156,15 +156,14 @@ class Bot<CTX extends Context> {
         isLocal = baseURL != RawAPI.defaultBase,
         _loggerOptions = loggerOptions,
         _scheme = scheme,
-        _api = RawAPI(token, loggerOptions: loggerOptions, timeout: timeout) {
-    _initializeBot(fetcher);
+        _api = RawAPI(token, loggerOptions: loggerOptions, timeout: timeout),
+        fetcher = fetcher ?? LongPolling<CTX>() {
+    // Set the default error handler
+    onError(_defaultErrorHandler);
   }
 
-  /// Function to ignore things.
-  void _ignore(_) {}
-
   /// Handles the error in initial `getMe` call
-  FutureOr<Null> _thenHandleGetMeError(Object err, StackTrace st) async {
+  Future<void> _thenHandleGetMeError(Object err, StackTrace st) async {
     if (err is DioException) {
       if (err.type == DioExceptionType.connectionTimeout ||
           err.type == DioExceptionType.receiveTimeout ||
@@ -232,29 +231,25 @@ class Bot<CTX extends Context> {
         _loggerOptions = api._httpClient.loggerOptions,
         _scheme = api._scheme,
         timeout = api.timeout,
-        token = api.token {
-    _initializeBot(fetcher);
+        token = api.token,
+        fetcher = fetcher ?? LongPolling<CTX>() {
+    onError(_defaultErrorHandler);
   }
 
   /// Initializes the bot with common setup logic.
-  void _initializeBot(Fetcher<CTX>? fetcher) {
+  Future<void> _initializeBot() async {
     // Create Fetcher and assign the RawAPI instance
-    this.fetcher = fetcher ?? LongPolling<CTX>();
-    this.fetcher.setApi(_api!);
-
-    // Set the default error handler
-    onError(_defaultErrorHandler);
+    fetcher.setApi(_api!);
 
     // Perform initial /getMe request
-    _getMeRequest = getMe();
-    _getMeRequest!.then(_ignore).catchError(_thenHandleGetMeError);
-
+    try {
+      await getMe();
+    } catch (err, st) {
+      _thenHandleGetMeError(err, st);
+    }
     // Set instance variable
     _instance = this;
   }
-
-  /// List of pending calls
-  final List<_PendingCall> _pendingCalls = [];
 
   /// (Internal) A Future that resolves to User of Bot info.
   ///
@@ -268,24 +263,21 @@ class Bot<CTX extends Context> {
   bool get initialized => _getMeStatus == _GetMeStatus.completed;
 
   /// Information about the bot.
-  late User _me;
+  User? _me;
 
   /// Get information about the bot.
   ///
   /// This getter returns the bot information. You can use this to access the bot information from anywhere in your code. This getter will be automatically set when the bot starts.
   /// If you try to access this getter before creating a bot instance, it will throw an error.
   User get me {
-    try {
-      return _me;
-    } catch (err, stack) {
-      throw TeleverseException(
-        "Bot information not found.",
-        description:
-            "This happens when the initial getMe request is not completed. You can call `bot.getMe` method to set this property.",
-        stackTrace: stack,
-        type: TeleverseExceptionType.requestFailed,
-      );
-    }
+    if (_me != null) return _me!;
+
+    throw TeleverseException(
+      "Bot information not found.",
+      description:
+          "This happens when the initial getMe request is not completed. You can call `bot.getMe` method to set this property.",
+      type: TeleverseExceptionType.requestFailed,
+    );
   }
 
   /// Get information about the bot.
@@ -296,21 +288,13 @@ class Bot<CTX extends Context> {
   /// Note: As of now this won't be handled in `onError` handler.
   Future<User> getMe() async {
     try {
-      if (initialized) {
-        return _me;
-      }
+      if (_me != null) return _me!;
+
       _getMeStatus = _GetMeStatus.pending;
       _me = await api.getMe();
       _getMeStatus = _GetMeStatus.completed;
 
-      if (_pendingCalls.isNotEmpty) {
-        for (final fn in _pendingCalls) {
-          fn.call();
-        }
-        _pendingCalls.clear();
-      }
-
-      return _me;
+      return _me!;
     } catch (err, stack) {
       final exception = TeleverseException.getMeRequestFailed(err, stack);
       throw exception;
@@ -366,14 +350,8 @@ class Bot<CTX extends Context> {
       return scope.types.contains(update.type);
     }
 
-    // Checks has
-    final hasMiddlewares = _middlewares.isNotEmpty;
-
     // Gets the sublist of Handler Scopes that is apt for the recieved Update
-    List<HandlerScope<CTX>> sub =
-        (hasMiddlewares ? _handlerScopes : _handlerScopes.reversed)
-            .where(matchScopes)
-            .toList();
+    final sub = _handlerScopes.where(matchScopes).toList();
 
     // Sorter helper method that brings handler scopes that has custom predicate to front
     int bringCustomChecksFirst(HandlerScope<CTX> a, HandlerScope<CTX> b) {
@@ -391,28 +369,6 @@ class Bot<CTX extends Context> {
       me: !initialized ? await _getMeRequest! : me,
       update: update,
     );
-
-    // Indexes of the forked Handler Scopes
-    final forks = sub.indexed
-        .where((s) => s.$2.forked)
-        .map(
-          (e) => e.$1,
-        )
-        .toList();
-
-    // Processes forked handlers first
-    for (int i = 0; i < forks.length; i++) {
-      final passing = sub[forks[i]].predicate(context);
-      if (!passing) continue;
-      _preProcess(sub[forks[i]], context);
-      await _processUpdate(sub[forks[i]], context);
-    }
-
-    // Once completed, remove the forked handlers in the decending order.
-    forks.sort((a, b) => b.compareTo(a));
-    for (final i in forks) {
-      sub.removeAt(i);
-    }
 
     // Finds and processes the handler scopes.
     for (int i = 0; i < sub.length; i++) {
@@ -624,6 +580,8 @@ class Bot<CTX extends Context> {
   Future<void> start({
     bool shouldSetWebhook = true,
   }) async {
+    await _initializeBot();
+
     fetcher.onUpdate().listen(
       _onUpdate,
       onDone: () {
@@ -680,46 +638,31 @@ class Bot<CTX extends Context> {
     ScopeOptions<CTX>? options,
     bool considerCaption = false,
   }) {
-    if (initialized) {
-      final scope = HandlerScope<CTX>(
-        isCommand: true,
-        options: options,
-        handler: callback,
-        types: UpdateType.messages(),
-        predicate: (ctx) {
-          String? text;
-          if (considerCaption) {
-            text = ctx.msg?.caption;
-          }
-          text ??= ctx.msg?.text;
+    final scope = HandlerScope<CTX>(
+      isCommand: true,
+      options: options,
+      handler: callback,
+      types: UpdateType.messages(),
+      predicate: (ctx) {
+        String? text;
+        if (considerCaption) {
+          text = ctx.msg?.caption;
+        }
+        text ??= ctx.msg?.text;
 
-          if (text == null) return false;
-          if (command is RegExp) {
-            return command.hasMatch(text);
-          } else if (command is String) {
-            final firstTerm = text.split(' ').first;
-            final suffix = '@${me.username}';
-            return firstTerm == '/$command' || firstTerm == '/$command$suffix';
-          }
-          return false;
-        },
-      );
-      _handlerScopes.add(scope);
-      return;
-    }
-
-    if (_getMeStatus == _GetMeStatus.pending) {
-      _pendingCalls.add(
-        _PendingCall(
-          fn: this.command,
-          params: [command, callback],
-          namedParams: {
-            #options: options,
-            #considerCaption: considerCaption,
-          },
-        ),
-      );
-    }
+        if (text == null) return false;
+        if (command is RegExp) {
+          return command.hasMatch(text);
+        } else if (command is String) {
+          final firstTerm = text.split(' ').first;
+          final suffix = '@${me.username}';
+          return firstTerm == '/$command' || firstTerm == '/$command$suffix';
+        }
+        return false;
+      },
+    );
+    _handlerScopes.add(scope);
+    return;
   }
 
   /// Registers a Handler Scope to listen to matching callback query.
@@ -1484,24 +1427,11 @@ class Bot<CTX extends Context> {
     Handler<CTX> callback, {
     ScopeOptions<CTX>? options,
   }) async {
-    if (initialized) {
-      return onMention(
-        callback,
-        username: me.username,
-        options: options,
-      );
-    }
-    if (_getMeStatus == _GetMeStatus.pending) {
-      _pendingCalls.add(
-        _PendingCall(
-          fn: whenMentioned,
-          params: [callback],
-          namedParams: {
-            #options: options,
-          },
-        ),
-      );
-    }
+    return onMention(
+      callback,
+      username: me.username,
+      options: options,
+    );
   }
 
   /// Registers a callback for all Message updates

--- a/lib/src/televerse/context/context.dart
+++ b/lib/src/televerse/context/context.dart
@@ -16,6 +16,15 @@ class Context {
   /// This represents the update for which the context is created.
   final Update update;
 
+  /// Possibly the [ChatID] of the chat which the update belongs to.
+  ///
+  /// This is a lighter version of [id]. Instead of throwing an exception,
+  /// this getter will return null if the udpate does not have a chat.
+  ChatID? get maybeId {
+    if (_chatId == null) return null;
+    return ChatID(_chatId!);
+  }
+
   /// The [ChatID] instance.
   ///
   /// This represents the ID of the chat from which the update was sent.

--- a/lib/src/televerse/context/methods.dart
+++ b/lib/src/televerse/context/methods.dart
@@ -649,7 +649,7 @@ extension ContextAwareMethods on Context {
     }
 
     await api._editMessageLiveLocation<_Ignore>(
-      chatId: id,
+      chatId: maybeId,
       messageId: _msgId,
       inlineMessageId: _inlineMsgId,
       latitude: latitude,
@@ -1545,7 +1545,7 @@ extension ContextAwareMethods on Context {
 
     await api._editMessageText<_Ignore>(
       text: text,
-      chatId: id,
+      chatId: maybeId,
       inlineMessageId: _inlineMsgId,
       messageId: _msgId,
       parseMode: parseMode,
@@ -1573,7 +1573,7 @@ extension ContextAwareMethods on Context {
     }
 
     await api._editMessageCaption<_Ignore>(
-      chatId: id,
+      chatId: maybeId,
       messageId: _msgId,
       inlineMessageId: _inlineMsgId,
       caption: caption,
@@ -1603,7 +1603,7 @@ extension ContextAwareMethods on Context {
 
     await api._editMessageMedia<_Ignore>(
       inlineMessageId: _inlineMsgId,
-      chatId: id,
+      chatId: maybeId,
       messageId: _msgId,
       media: media,
       replyMarkup: replyMarkup,
@@ -1625,7 +1625,7 @@ extension ContextAwareMethods on Context {
     }
 
     await api._editMessageReplyMarkup<_Ignore>(
-      chatId: id,
+      chatId: maybeId,
       messageId: _msgId,
       inlineMessageId: _inlineMsgId,
       replyMarkup: replyMarkup,

--- a/lib/src/televerse/context/methods.dart
+++ b/lib/src/televerse/context/methods.dart
@@ -1800,7 +1800,7 @@ extension ContextAwareMethods on Context {
   }
 
   /// Answer pre checkout query
-  Future<bool> answerPreCheckouQUery(
+  Future<bool> answerPreCheckouQuery(
     bool ok, {
     String? errorMessage,
   }) async {

--- a/lib/src/televerse/models/handler_scope.dart
+++ b/lib/src/televerse/models/handler_scope.dart
@@ -44,12 +44,12 @@ class HandlerScope<CTX extends Context> {
     this.options,
   }) : assert(handler != null || isConversation);
 
-  /// Whether the scope is forked or not.
-  bool get forked => options?.forked ?? false;
-
   /// Name of the scope
   String? get name => options?.name;
 
   /// Whether the scope has a custom predicate
   bool get hasCustomPredicate => options?.customPredicate != null;
+
+  @override
+  String toString() => options?.name ?? 'Unnamed';
 }

--- a/lib/src/televerse/models/scope_options.dart
+++ b/lib/src/televerse/models/scope_options.dart
@@ -7,15 +7,6 @@ class ScopeOptions<CTX extends Context> {
   /// This can be used to remove a Handler later on your code.
   final String? name;
 
-  /// Whether the scope is forked.
-  ///
-  /// By default fork is set to `false` that is once a matching scope is found
-  /// the processor only executes that particular scope and skips all the rest.
-  ///
-  /// When fork is set to `true` the successive Handler Scope is also considered
-  /// and executed if it satisfies the predicate.
-  final bool forked;
-
   /// Custom Predicate Method
   ///
   /// Often some handlers require restricted access, like admin controls or bans.
@@ -28,9 +19,6 @@ class ScopeOptions<CTX extends Context> {
   ///
   /// This approach keeps your code clean and avoids repetitive permission checks.
   ///
-  /// Note: [forked] overrides this. That is even if [customPredicate] may evaluate
-  /// to `false` if [forked] is true the handler is executed.
-  ///
   /// If by any reason, this method threw any exception, it'll be caught in the passed `Bot.onError` if set.
   /// Otherwise, treated as `false` evaluation and skips the current handler.
   final FutureOr<bool> Function(CTX ctx)? customPredicate;
@@ -38,29 +26,16 @@ class ScopeOptions<CTX extends Context> {
   /// Constructs a `ScopeOption`.
   ///
   /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
-  ///
-  /// - [forked] - A flag used to determine whether the succeeding handler should also be executed
   const ScopeOptions({
-    this.forked = false,
     this.name,
     this.customPredicate,
   });
-
-  /// Constructs a `ScopeOption` that is forked. This scope will allow the processing of subsequent handler scope as well.
-  ///
-  /// - [name] - Name of the Handler Scope. This can be used to remove the scope later.
-  /// - [customPredicate] - Middleware to check if the update should be processed or skipped.
-  const ScopeOptions.forked({
-    this.name,
-    this.customPredicate,
-  }) : forked = true;
 
   /// Creates a copy of this [ScopeOptions] object with potentially modified properties.
 
   /// Provides options to override the following properties:
   ///
   /// * [name]: The name of the scope. If not provided, it will be inherited from the original object.
-  /// * [forked]: Whether the scope is forked. If not provided, it will be inherited from the original object.
   /// * [customPredicate]: A custom predicate function that determines when updates within the scope are processed.
   ///   If not provided, it will be inherited from the original object.
   ///
@@ -70,12 +45,10 @@ class ScopeOptions<CTX extends Context> {
   /// Returns a new instance of [ScopeOptions] with the updated properties.
   ScopeOptions<CTX> copyWith({
     String? name,
-    bool? forked,
     FutureOr<bool> Function(CTX ctx)? customPredicate,
   }) {
     return ScopeOptions<CTX>(
       name: name ?? this.name,
-      forked: forked ?? this.forked,
       customPredicate: customPredicate ?? this.customPredicate,
     );
   }
@@ -84,20 +57,17 @@ class ScopeOptions<CTX extends Context> {
   static ScopeOptions<CTX> _createOrCopy<CTX extends Context>(
     ScopeOptions<CTX>? options, {
     String? name,
-    bool? forked,
     FutureOr<bool> Function(CTX ctx)? customPredicate,
   }) {
     if (options != null) {
       return options.copyWith(
         name: name,
-        forked: forked,
         customPredicate: customPredicate,
       );
     }
 
     return ScopeOptions<CTX>(
       name: name,
-      forked: forked ?? false,
       customPredicate: customPredicate,
     );
   }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -106,23 +106,6 @@ enum _GetMeStatus {
   ;
 }
 
-/// Represents a pending method call
-class _PendingCall {
-  final Function fn;
-  final List<dynamic> params;
-  final Map<Symbol, dynamic> namedParams;
-
-  const _PendingCall({
-    required this.fn,
-    required this.params,
-    this.namedParams = const <Symbol, dynamic>{},
-  });
-
-  void call() {
-    Function.apply(fn, params, namedParams);
-  }
-}
-
 /// Extension on `Chat` to create ID of the chat
 extension GetChatID on Chat {
   /// Returns the `ChatID` of the chat.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: televerse
 description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.6!
-version: 1.21.1
+version: 1.22.0
 homepage: https://github.com/HeySreelal/televerse
 topics:
   - telegram

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: televerse
-description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.6!
+description: Televerse lets you create your own efficient Telegram bots with ease in Dart. Supports latest Telegram Bot API - 7.7!
 version: 1.22.0
 homepage: https://github.com/HeySreelal/televerse
 topics:


### PR DESCRIPTION
# 1.22.0

- 🤖 Bot API 7.7
- Added the `RefundedPayment` class and the `Message.refundedPayment` property
- Initalizes fetcher on the constructor
- Moved the inital `getMe` call to be made from hte `Bot.start` method
- Remoed Pending Calls (which caused some troubles in the handler scopes order)
- Removed forked handlers, - well who knew it was there?
- All thanks to [@im-trisha](https://github.com/im-trisha)
- Fixed an issue that caused Bot to listen to the official Bot API even though
  created with `Bot.local` -
  [#275](https://github.com/HeySreelal/televerse/issues/275) (Thanks to
  [@devdocs](https://github.com/devsdocs) for reporting)
- Fixed [#274](https://github.com/HeySreelal/televerse/issues/274)
- Fix [#277](https://github.com/HeySreelal/televerse/issues/277)
- Fix [#104](https://github.com/HeySreelal/televerse/issues/104)
- Fixed more typing issues.
- `Bot.start` now accepts zero parameters.
- Added `Context.maybeId` a nullable ID instance