### PR TITLE
Fix #281: `api` re-initialization

### DIFF
--- a/lib/src/televerse/fetch/fetch.dart
+++ b/lib/src/televerse/fetch/fetch.dart
@@ -1,20 +1,4 @@
-/// Televerse Fetcher
-///
-/// This library contains the fetcher classes. Fetchers are used to fetch updates from the Telegram API. Currently, there are two fetchers: [LongPolling] and [Webhook].
-///
-/// [LongPolling] - This fetcher uses the `getUpdates` method to fetch updates. It is the default fetcher.
-///
-/// [Webhook] - This fetcher uses the `setWebhook` method to set a webhook. It is used when you want to host your bot on a server.
-library;
-
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io' as io;
-import 'package:televerse/telegram.dart';
-import 'package:televerse/televerse.dart';
-
-part 'long_polling.dart';
-part 'webhook.dart';
+part of '../../../televerse.dart';
 
 /// **Fetcher** - This is the base class for all fetchers. It is used to fetch updates from the Telegram API.
 /// You can use this class to create your own fetcher. Currently, there are two fetchers: [LongPolling] and [Webhook].

--- a/lib/src/televerse/fetch/fetch.dart
+++ b/lib/src/televerse/fetch/fetch.dart
@@ -33,6 +33,15 @@ sealed class Fetcher<CTX extends Context> {
   /// Stops fetching updates.
   Future<void> stop();
 
+  /// Update Stream Subscription
+  StreamSubscription<Update>? _updateSubscription;
+
+  /// Pause the stream
+  Future<void> pause();
+
+  /// Resume the stream
+  Future<void> resume();
+
   /// Raw API instance.
   late final RawAPI api;
 

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -159,4 +159,16 @@ class LongPolling<CTX extends Context> extends Fetcher<CTX> {
   /// Flag to check if the long polling is active.
   @override
   bool get isActive => _isPolling;
+
+  @override
+  Future<void> pause() async {
+    _isPolling = false;
+    _updateSubscription?.pause();
+  }
+
+  @override
+  Future<void> resume() async {
+    _updateSubscription?.resume();
+    return start();
+  }
 }

--- a/lib/src/televerse/fetch/long_polling.dart
+++ b/lib/src/televerse/fetch/long_polling.dart
@@ -1,4 +1,4 @@
-part of 'fetch.dart';
+part of '../../../televerse.dart';
 
 /// A class that handles long polling.
 /// This class is used to fetch updates from the Telegram API. It uses the long polling method.

--- a/lib/src/televerse/fetch/webhook.dart
+++ b/lib/src/televerse/fetch/webhook.dart
@@ -240,6 +240,8 @@ class Webhook extends Fetcher {
     );
   }
 
+  StreamSubscription<io.HttpRequest>? _requestSubscription;
+
   /// Starts the webhook fetcher.
   ///
   /// It sets the webhook and listens to the server.
@@ -248,7 +250,7 @@ class Webhook extends Fetcher {
     final webhookSet = shouldSetWebhook ? await setWebhook() : true;
     if (webhookSet) {
       _isActive = true;
-      server.listen(_handleRequest);
+      _requestSubscription = server.listen(_handleRequest);
     } else {
       throw WebhookException.failedToSetWebhook;
     }
@@ -308,4 +310,16 @@ class Webhook extends Fetcher {
   /// Flag to check if the webhook is running.
   @override
   bool get isActive => _isActive;
+
+  @override
+  Future<void> pause() async {
+    _isActive = false;
+    _requestSubscription?.pause();
+  }
+
+  @override
+  Future<void> resume() {
+    _requestSubscription?.resume();
+    return start();
+  }
 }

--- a/lib/src/televerse/fetch/webhook.dart
+++ b/lib/src/televerse/fetch/webhook.dart
@@ -1,4 +1,4 @@
-part of 'fetch.dart';
+part of '../../../televerse.dart';
 
 /// A fetcher class that handles incoming updates from the Telegram Bot API via a webhook.
 ///

--- a/lib/televerse.dart
+++ b/lib/televerse.dart
@@ -31,7 +31,6 @@ import 'package:televerse/telegram.dart';
 import 'package:televerse/televerse.dart';
 
 export 'src/televerse/extensions/extensions.dart';
-export 'src/televerse/fetch/fetch.dart';
 export 'src/televerse/links/links.dart';
 export 'src/televerse/models/models.dart';
 export 'src/types/types.dart';
@@ -54,6 +53,10 @@ part 'src/televerse/models/multipart_helper.dart';
 part 'src/utils/date.dart';
 part 'src/utils/http.dart';
 part 'src/utils/utils.dart';
+
+part 'src/televerse/fetch/fetch.dart';
+part 'src/televerse/fetch/long_polling.dart';
+part 'src/televerse/fetch/webhook.dart';
 
 /// Conversation API
 part 'src/televerse/conversation/conversation.dart';


### PR DESCRIPTION
Fixes #281 

## What happened?

When the `bot.start()` is called twice regardless called consecutively or not - we call the `_initializeBot` method which in turn sets the `RawAPI` instance to the fetcher and performs the initial get me request.

The API instance on Fetcher is defined as:

```dart
  /// Raw API instance.
  late final RawAPI api;
```

And when we try to set the RawAPI instance for the second time (where it was already set) the system comes to crash as final variables cannot be set again.


## What changed?

Added two methods, namely `pause` and `resume` to the Bot class to pause fetcher temporarily. 

- Added `Bot.pause`
- Added `Bot.resume`

## Why?

When the `bot.stop()` is called Televerse actually closes all the related resources - this includes Fetchers (`LongPolling` / `Webhook`), the underlying `Dio` instance (used for making http calls), etc.

So, instead of creating all the related instances once again, it's better to implement a pause/resume feature which can temporarily hold the update streaming.

Being said that `Bot.stop` now should only be called when you actually want to stop the bot and release all resources.



